### PR TITLE
feat: pread-based parallel I/O + zigtable terminal output

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,12 @@ pub fn build(b: *std.Build) void {
     });
     exe.linkLibC();
 
+    const zigtable_dep = b.dependency("zigtable", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("zigtable", zigtable_dep.module("zigtable"));
+
     b.installArtifact(exe);
 
     // Run command

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .csvql,
+    .version = "0.15.2",
+    .dependencies = .{
+        .zigtable = .{
+            .url = "https://github.com/melihbirim/zigtable/archive/refs/tags/v0.1.0.tar.gz",
+            .hash = "N-V-__8AAMR1AAAivmAvIvQAr05b7l_7idWEaWMDruD_Ug2Z",
+        },
+    },
+    .paths = .{""},
+    .fingerprint = 0x436684d4739c7bd9,
+}

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -667,7 +667,7 @@ fn executeSequential(
 // ─────────────────────────────────────────────────────────────────────────────
 
 const ScalarWorkerCtx = struct {
-    data: []const u8,
+    file_path: []const u8,
     chunk_start: usize,
     chunk_end: usize,
     output_specs: []const scalar.OutputColSpec,
@@ -687,29 +687,127 @@ fn scalarWorkerThread(ctx: *ScalarWorkerCtx) void {
 }
 
 fn scalarProcessChunk(ctx: *ScalarWorkerCtx) !void {
-    const chunk_data = ctx.data[ctx.chunk_start..ctx.chunk_end];
-
     // Per-row arena: reset after each row so scalar allocations (UPPER/LOWER etc.)
     // don't accumulate.  Capacity is retained so there's no system-call overhead
     // after the first few rows.
     var row_arena = std.heap.ArenaAllocator.init(ctx.allocator);
     defer row_arena.deinit();
 
+    // Chunk-level I/O buffers: live for the entire scan (not reset per row).
+    const IO_BUF: usize = 2 * 1024 * 1024;
+    const io_buf = try ctx.allocator.alloc(u8, IO_BUF);
+    defer ctx.allocator.free(io_buf);
+    var seam_buf = std.ArrayListUnmanaged(u8){};
+    defer seam_buf.deinit(ctx.allocator);
+    var combined_buf = std.ArrayListUnmanaged(u8){};
+    defer combined_buf.deinit(ctx.allocator);
+
+    const file = try std.fs.cwd().openFile(ctx.file_path, .{});
+    defer file.close();
+
     var field_buf: [256][]const u8 = undefined;
-    var line_start: usize = 0;
 
-    while (line_start < chunk_data.len) {
-        _ = row_arena.reset(.retain_capacity);
+    var file_pos: usize = ctx.chunk_start;
+    while (file_pos < ctx.chunk_end) {
+        const to_read = @min(IO_BUF, ctx.chunk_end - file_pos);
+        const n = try std.posix.pread(file.handle, io_buf[0..to_read], @intCast(file_pos));
+        if (n == 0) break;
+        file_pos += n;
 
-        const remaining = chunk_data[line_start..];
-        const line_end_off = std.mem.indexOfScalar(u8, remaining, '\n') orelse
-            chunk_data.len - line_start;
-        var line = remaining[0..line_end_off];
+        var scan: usize = 0;
+        while (scan < n) {
+            const nl = std.mem.indexOfScalarPos(u8, io_buf, scan, '\n') orelse {
+                try seam_buf.appendSlice(ctx.allocator, io_buf[scan..n]);
+                break;
+            };
+            var line: []const u8 = undefined;
+            if (seam_buf.items.len > 0) {
+                combined_buf.clearRetainingCapacity();
+                try combined_buf.appendSlice(ctx.allocator, seam_buf.items);
+                try combined_buf.appendSlice(ctx.allocator, io_buf[scan..nl]);
+                seam_buf.clearRetainingCapacity();
+                line = combined_buf.items;
+            } else {
+                line = io_buf[scan..nl];
+            }
+            if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
+            scan = nl + 1;
+            if (line.len == 0) continue;
+
+            _ = row_arena.reset(.retain_capacity);
+
+            // Parse all fields into stack buffer (zero-alloc)
+            var n_fields: usize = 0;
+            var it = std.mem.splitScalar(u8, line, ctx.delimiter);
+            while (it.next()) |f| {
+                if (n_fields >= field_buf.len) break;
+                field_buf[n_fields] = f;
+                n_fields += 1;
+            }
+            const fields = field_buf[0..n_fields];
+
+            // WHERE filter
+            if (ctx.where_expr) |expr| {
+                if (expr == .comparison) {
+                    const comp = expr.comparison;
+                    if (ctx.where_column_idx) |ci| {
+                        const fv = if (ci < fields.len) fields[ci] else "";
+                        if (comp.numeric_value) |threshold| {
+                            const val = std.fmt.parseFloat(f64, fv) catch continue;
+                            const ok = switch (comp.operator) {
+                                .equal => val == threshold,
+                                .not_equal => val != threshold,
+                                .greater => val > threshold,
+                                .greater_equal => val >= threshold,
+                                .less => val < threshold,
+                                .less_equal => val <= threshold,
+                                .like => parser.matchLike(fv, comp.value),
+                                .ilike => parser.matchILike(fv, comp.value),
+                                .between, .is_null, .is_not_null => parser.compareValues(comp, fv),
+                            };
+                            if (!ok) continue;
+                        } else {
+                            if (!parser.compareValues(comp, fv)) continue;
+                        }
+                    } else continue;
+                } else {
+                    // AND/OR/NOT — no HashMap needed
+                    if (!parser.evaluateDirect(expr, fields, ctx.lower_header)) continue;
+                }
+            }
+
+            // Project through scalar specs and write CSV row to per-thread buffer
+            for (ctx.output_specs, 0..) |spec, j| {
+                if (j > 0) try ctx.output_buf.append(ctx.allocator, ctx.delimiter);
+                const value = scalar.evalOutputCol(spec, fields, row_arena.allocator());
+                // Minimal CSV quoting
+                var needs_quote = false;
+                for (value) |c| {
+                    if (c == ctx.delimiter or c == '"' or c == '\r' or c == '\n') {
+                        needs_quote = true;
+                        break;
+                    }
+                }
+                if (needs_quote) {
+                    try ctx.output_buf.append(ctx.allocator, '"');
+                    for (value) |c| {
+                        if (c == '"') try ctx.output_buf.append(ctx.allocator, '"');
+                        try ctx.output_buf.append(ctx.allocator, c);
+                    }
+                    try ctx.output_buf.append(ctx.allocator, '"');
+                } else {
+                    try ctx.output_buf.appendSlice(ctx.allocator, value);
+                }
+            }
+            try ctx.output_buf.append(ctx.allocator, '\n');
+        }
+    }
+    // Flush any partial line remaining in the seam buffer
+    if (seam_buf.items.len > 0) flush: {
+        var line: []const u8 = seam_buf.items;
         if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
-        line_start += line_end_off + 1;
-        if (line.len == 0) continue;
-
-        // Parse all fields into stack buffer (zero-alloc)
+        if (line.len == 0) break :flush;
+        _ = row_arena.reset(.retain_capacity);
         var n_fields: usize = 0;
         var it = std.mem.splitScalar(u8, line, ctx.delimiter);
         while (it.next()) |f| {
@@ -718,15 +816,13 @@ fn scalarProcessChunk(ctx: *ScalarWorkerCtx) !void {
             n_fields += 1;
         }
         const fields = field_buf[0..n_fields];
-
-        // WHERE filter
         if (ctx.where_expr) |expr| {
             if (expr == .comparison) {
                 const comp = expr.comparison;
                 if (ctx.where_column_idx) |ci| {
                     const fv = if (ci < fields.len) fields[ci] else "";
                     if (comp.numeric_value) |threshold| {
-                        const val = std.fmt.parseFloat(f64, fv) catch continue;
+                        const val = std.fmt.parseFloat(f64, fv) catch break :flush;
                         const ok = switch (comp.operator) {
                             .equal => val == threshold,
                             .not_equal => val != threshold,
@@ -738,22 +834,18 @@ fn scalarProcessChunk(ctx: *ScalarWorkerCtx) !void {
                             .ilike => parser.matchILike(fv, comp.value),
                             .between, .is_null, .is_not_null => parser.compareValues(comp, fv),
                         };
-                        if (!ok) continue;
+                        if (!ok) break :flush;
                     } else {
-                        if (!parser.compareValues(comp, fv)) continue;
+                        if (!parser.compareValues(comp, fv)) break :flush;
                     }
-                } else continue;
+                } else break :flush;
             } else {
-                // AND/OR/NOT — no HashMap needed
-                if (!parser.evaluateDirect(expr, fields, ctx.lower_header)) continue;
+                if (!parser.evaluateDirect(expr, fields, ctx.lower_header)) break :flush;
             }
         }
-
-        // Project through scalar specs and write CSV row to per-thread buffer
         for (ctx.output_specs, 0..) |spec, j| {
             if (j > 0) try ctx.output_buf.append(ctx.allocator, ctx.delimiter);
             const value = scalar.evalOutputCol(spec, fields, row_arena.allocator());
-            // Minimal CSV quoting
             var needs_quote = false;
             for (value) |c| {
                 if (c == ctx.delimiter or c == '"' or c == '\r' or c == '\n') {
@@ -900,7 +992,7 @@ fn executeParallelScalar(
             if (std.mem.indexOfScalarPos(u8, data, end, '\n')) |nl| end = nl + 1;
         }
         worker_ctxs[i] = ScalarWorkerCtx{
-            .data = data,
+            .file_path = query.file_path,
             .chunk_start = start,
             .chunk_end = end,
             .output_specs = output_specs,
@@ -2739,7 +2831,9 @@ fn splitLineChunks(
 /// after the merge frees everything (partial_map, keys, CompactAccum arrays).
 const GbWorkerCtx = struct {
     // Shared read-only inputs
-    data: []const u8, // mmap slice for this worker's chunk (zero-copy)
+    file_path: []const u8, // path opened independently by each worker thread
+    chunk_start: usize, // byte offset into the file where this worker's chunk begins
+    chunk_end: usize, // byte offset where this worker's chunk ends (exclusive)
     lower_header: []const []const u8,
     group_specs: []const GroupSpec,
     agg_specs: []const AggSpec,
@@ -2895,9 +2989,8 @@ fn gbWorkerThread(ctx: *GbWorkerCtx) void {
 fn gbWorkerScan(ctx: *GbWorkerCtx) !void {
     const aa = ctx.arena.allocator();
     ctx.partial_map = std.StringHashMap(CompactAccum).init(aa);
-    // Per-thread map pre-sizing: each worker handles 1/N of the file
-    // Use same adaptive sizing as main thread since chunk size correlates with total file size
-    const chunk_size = ctx.data.len;
+    // Per-thread map pre-sizing based on chunk byte range
+    const chunk_size = ctx.chunk_end - ctx.chunk_start;
     const worker_capacity: u32 = if (chunk_size < 10 * 1024 * 1024)
         128
     else if (chunk_size < 100 * 1024 * 1024)
@@ -2906,29 +2999,56 @@ fn gbWorkerScan(ctx: *GbWorkerCtx) !void {
         2048;
     try ctx.partial_map.ensureTotalCapacity(worker_capacity);
 
-    // Zero-copy scan: iterate directly over the mmap'd data slice.
-    // The full file is already mmap'd by the calling thread; each worker
-    // just reads a pointer range — no pread syscalls, no data copies,
-    // no IO buffers, no seam handling.  After the warmup run the pages
-    // are in the page cache so access is at memory speed (~100 GB/s).
+    // Each worker opens the file independently and reads via pread.
+    // This avoids mmap page-fault serialization on macOS for large files:
+    // concurrent pread calls are served by separate kernel I/O paths, letting
+    // all 12 cores read in parallel rather than queuing behind a single
+    // page-fault handler.
+    const file = try std.fs.cwd().openFile(ctx.file_path, .{});
+    defer file.close();
+
+    const IO_BUF: usize = 2 * 1024 * 1024;
+    const io_buf = try aa.alloc(u8, IO_BUF);
+    var seam_buf = std.ArrayListUnmanaged(u8){};
+    var combined_buf = std.ArrayListUnmanaged(u8){};
+
     var field_stk: [256][]const u8 = undefined;
     var key_buf = std.ArrayListUnmanaged(u8){};
 
-    var pos: usize = 0;
-    const data = ctx.data;
-    while (pos < data.len) {
-        const nl = std.mem.indexOfScalarPos(u8, data, pos, '\n') orelse {
-            // Last line with no trailing newline
-            var line: []const u8 = data[pos..];
+    var file_pos: usize = ctx.chunk_start;
+    while (file_pos < ctx.chunk_end) {
+        const to_read = @min(IO_BUF, ctx.chunk_end - file_pos);
+        const n = try std.posix.pread(file.handle, io_buf[0..to_read], @intCast(file_pos));
+        if (n == 0) break;
+        file_pos += n;
+
+        var scan: usize = 0;
+        while (scan < n) {
+            const nl = std.mem.indexOfScalarPos(u8, io_buf, scan, '\n') orelse {
+                try seam_buf.appendSlice(aa, io_buf[scan..n]);
+                break;
+            };
+            var line: []const u8 = undefined;
+            if (seam_buf.items.len > 0) {
+                combined_buf.clearRetainingCapacity();
+                try combined_buf.appendSlice(aa, seam_buf.items);
+                try combined_buf.appendSlice(aa, io_buf[scan..nl]);
+                seam_buf.clearRetainingCapacity();
+                line = combined_buf.items;
+            } else {
+                line = io_buf[scan..nl];
+            }
             if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
-            if (line.len > 0) try gbProcessRecord(ctx, aa, &field_stk, &key_buf, line);
-            break;
-        };
-        var line: []const u8 = data[pos..nl];
+            scan = nl + 1;
+            if (line.len == 0) continue;
+            try gbProcessRecord(ctx, aa, &field_stk, &key_buf, line);
+        }
+    }
+    // Flush any partial line remaining in the seam buffer
+    if (seam_buf.items.len > 0) {
+        var line: []const u8 = seam_buf.items;
         if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
-        pos = nl + 1;
-        if (line.len == 0) continue;
-        try gbProcessRecord(ctx, aa, &field_stk, &key_buf, line);
+        if (line.len > 0) try gbProcessRecord(ctx, aa, &field_stk, &key_buf, line);
     }
 }
 
@@ -3494,7 +3614,9 @@ fn executeGroupBy(
 
         for (0..n_threads) |i| {
             thread_ctxs[i] = .{
-                .data = data[chunks[i][0]..chunks[i][1]],
+                .file_path = query.file_path,
+                .chunk_start = chunks[i][0],
+                .chunk_end = chunks[i][1],
                 .lower_header = lower_header,
                 .group_specs = group_specs,
                 .agg_specs = agg_specs.items,

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,6 +4,7 @@ const simple_parser = @import("simple_parser.zig");
 const engine = @import("engine.zig");
 const options_mod = @import("options.zig");
 const mcp = @import("mcp.zig");
+const zigtable = @import("zigtable");
 const Allocator = std.mem.Allocator;
 
 const version = "0.6.0";
@@ -119,6 +120,10 @@ pub fn main() !void {
             opts.format = .json;
         } else if (std.mem.eql(u8, arg, "--jsonl")) {
             opts.format = .jsonl;
+        } else if (std.mem.eql(u8, arg, "--table")) {
+            opts.table_mode = .on;
+        } else if (std.mem.eql(u8, arg, "--no-table")) {
+            opts.table_mode = .off;
         } else if (std.mem.eql(u8, arg, "-d") or std.mem.eql(u8, arg, "--delimiter")) {
             i += 1;
             if (i >= args.len) {
@@ -152,12 +157,158 @@ pub fn main() !void {
     };
     defer query.deinit();
 
-    // Execute query
-    engine.execute(allocator, query, stdout_file, opts) catch |err| {
-        std.debug.print("execution error: {}\n", .{err});
-        std.process.exit(1);
+    // Determine whether to render as a table
+    const use_table = opts.format == .csv and !opts.no_header and switch (opts.table_mode) {
+        .on => true,
+        .off => false,
+        .auto => std.posix.isatty(std.posix.STDOUT_FILENO),
     };
+
+    if (use_table) {
+        renderTableOutput(allocator, query, stdout_file, opts) catch |err| {
+            std.debug.print("execution error: {}\n", .{err});
+            std.process.exit(1);
+        };
+    } else {
+        engine.execute(allocator, query, stdout_file, opts) catch |err| {
+            std.debug.print("execution error: {}\n", .{err});
+            std.process.exit(1);
+        };
+    }
 }
+
+/// Run the engine into a temp file, read back, parse CSV, render via zigtable.
+fn renderTableOutput(allocator: Allocator, query: parser.Query, stdout_file: std.fs.File, opts: options_mod.Options) !void {
+    // Write CSV to a temp file
+    var tmp_buf: [128]u8 = undefined;
+    const tmp_path = try std.fmt.bufPrint(&tmp_buf, "/tmp/csvql_{d}.tmp", .{std.time.milliTimestamp()});
+    {
+        const tmp_file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
+        defer tmp_file.close();
+        try engine.execute(allocator, query, tmp_file, opts);
+    }
+    defer std.fs.deleteFileAbsolute(tmp_path) catch {};
+
+    // Read back
+    const tmp_read = try std.fs.openFileAbsolute(tmp_path, .{});
+    defer tmp_read.close();
+    const csv_data = try tmp_read.readToEndAlloc(allocator, 4 * 1024 * 1024 * 1024);
+    defer allocator.free(csv_data);
+
+    // Parse header line into column definitions
+    var lines = std.mem.splitScalar(u8, csv_data, '\n');
+    const header_line_raw = lines.next() orelse return;
+    const header_line = if (header_line_raw.len > 0 and header_line_raw[header_line_raw.len - 1] == '\r')
+        header_line_raw[0 .. header_line_raw.len - 1]
+    else
+        header_line_raw;
+    if (header_line.len == 0) return;
+
+    var col_list: std.ArrayList(zigtable.Column) = .{};
+    defer col_list.deinit(allocator);
+    var hdr_it = CsvRowIterator.init(header_line, opts.delimiter);
+    while (hdr_it.next()) |col_name| {
+        try col_list.append(allocator, .{ .name = col_name });
+    }
+    if (col_list.items.len == 0) return;
+
+    var table = zigtable.Table.init(allocator, col_list.items);
+    defer table.deinit();
+
+    // Add data rows
+    var row_fields: std.ArrayList([]const u8) = .{};
+    defer row_fields.deinit(allocator);
+    while (lines.next()) |raw_line| {
+        const line = if (raw_line.len > 0 and raw_line[raw_line.len - 1] == '\r')
+            raw_line[0 .. raw_line.len - 1]
+        else
+            raw_line;
+        if (line.len == 0) continue;
+        row_fields.clearRetainingCapacity();
+        var row_it = CsvRowIterator.init(line, opts.delimiter);
+        while (row_it.next()) |field| {
+            try row_fields.append(allocator, field);
+        }
+        try table.addRow(row_fields.items);
+    }
+
+    // Buffer the table output, then write to stdout in one shot.
+    var table_buf: std.ArrayList(u8) = .{};
+    defer table_buf.deinit(allocator);
+
+    const BufWriter = struct {
+        buf: *std.ArrayList(u8),
+        alloc: Allocator,
+        const WriteError = error{OutOfMemory};
+        pub fn write(self: @This(), data: []const u8) WriteError!usize {
+            try self.buf.appendSlice(self.alloc, data);
+            return data.len;
+        }
+    };
+    try table.render(BufWriter{ .buf = &table_buf, .alloc = allocator });
+    try stdout_file.writeAll(table_buf.items);
+}
+
+/// Minimal CSV field iterator: handles quoted and unquoted fields.
+/// Returns slices into the original line (quotes stripped, no unescape).
+const CsvRowIterator = struct {
+    line: []const u8,
+    pos: usize,
+    delimiter: u8,
+    done: bool = false,
+
+    fn init(line: []const u8, delimiter: u8) CsvRowIterator {
+        return .{ .line = line, .pos = 0, .delimiter = delimiter };
+    }
+
+    fn next(self: *CsvRowIterator) ?[]const u8 {
+        if (self.done) return null;
+        if (self.pos > self.line.len) return null;
+        // Trailing empty field after a delimiter at end
+        if (self.pos == self.line.len) {
+            self.done = true;
+            return "";
+        }
+        if (self.line[self.pos] == '"') {
+            // Quoted field
+            self.pos += 1;
+            const start = self.pos;
+            while (self.pos < self.line.len) {
+                if (self.line[self.pos] == '"') {
+                    if (self.pos + 1 < self.line.len and self.line[self.pos + 1] == '"') {
+                        self.pos += 2; // skip escaped quote
+                    } else {
+                        const field = self.line[start..self.pos];
+                        self.pos += 1; // skip closing quote
+                        if (self.pos < self.line.len and self.line[self.pos] == self.delimiter) {
+                            self.pos += 1;
+                        } else {
+                            self.done = true;
+                        }
+                        return field;
+                    }
+                } else {
+                    self.pos += 1;
+                }
+            }
+            self.done = true;
+            return self.line[start..self.pos];
+        } else {
+            // Unquoted field
+            const start = self.pos;
+            while (self.pos < self.line.len and self.line[self.pos] != self.delimiter) {
+                self.pos += 1;
+            }
+            const field = self.line[start..self.pos];
+            if (self.pos < self.line.len) {
+                self.pos += 1; // skip delimiter
+            } else {
+                self.done = true;
+            }
+            return field;
+        }
+    }
+};
 
 /// Detect if argument is SQL query (starts with SELECT)
 fn isSQL(arg: []const u8) bool {

--- a/src/options.zig
+++ b/src/options.zig
@@ -8,6 +8,16 @@ pub const OutputFormat = enum {
     jsonl,
 };
 
+/// Table rendering mode.
+pub const TableMode = enum {
+    /// Auto-detect: use table when stdout is a TTY and format is csv.
+    auto,
+    /// Always render as a table (--table flag).
+    on,
+    /// Never render as a table (--no-table flag).
+    off,
+};
+
 /// Runtime options parsed from CLI flags.
 pub const Options = struct {
     /// Suppress the header row in output.
@@ -16,4 +26,6 @@ pub const Options = struct {
     delimiter: u8 = ',',
     /// Output format (default: csv).
     format: OutputFormat = .csv,
+    /// Table rendering mode (default: auto TTY detection).
+    table_mode: TableMode = .auto,
 };

--- a/src/parallel_mmap.zig
+++ b/src/parallel_mmap.zig
@@ -34,7 +34,8 @@ const WorkerResult = struct {
 };
 
 const WorkerContext = struct {
-    data: []const u8,
+    data: []const u8, // mmap slice — used only when use_parallel_output=false (LIMIT/DISTINCT)
+    file_path: []const u8, // used by pread path (use_parallel_output=true)
     chunk: WorkChunk,
     query: parser.Query,
     lower_header: []const []const u8,
@@ -190,7 +191,7 @@ pub fn executeParallelMapped(
 
     // Get number of threads
     const num_cores = try std.Thread.getCpuCount();
-    const num_threads = @min(num_cores, 8);
+    const num_threads = num_cores;
 
     // Split into chunks aligned to line boundaries
     const chunk_size = data_len / num_threads;
@@ -383,6 +384,7 @@ pub fn executeParallelMapped(
         for (0..num_threads) |i| {
             contexts[i] = WorkerContext{
                 .data = data,
+                .file_path = query.file_path,
                 .chunk = chunks[i],
                 .query = query,
                 .lower_header = lower_header,
@@ -590,154 +592,173 @@ fn workerThread(ctx: *WorkerContext) void {
     };
 }
 
-fn processChunk(ctx: *WorkerContext) !void {
-    const chunk_data = ctx.data[ctx.chunk.start..ctx.chunk.end];
+/// Process a single CSV line: apply WHERE filter then serialize or collect the result.
+/// Called by both the pread (use_parallel_output=true) and mmap scan loops in processChunk.
+/// Returns immediately (row skipped) when the WHERE condition is not satisfied.
+fn processOneLine(
+    ctx: *WorkerContext,
+    arena_alloc: Allocator,
+    fields: *std.ArrayList([]const u8),
+    line: []const u8,
+) !void {
+    fields.clearRetainingCapacity();
+    try simd.parseCSVFields(line, fields, arena_alloc, ctx.delimiter);
 
-    // Use arena allocator for temporary allocations
+    // Fast WHERE evaluation using direct index lookup (avoid HashMap!)
+    if (ctx.query.where_expr) |expr| {
+        if (expr == .comparison) {
+            const comp = expr.comparison;
+            if (ctx.where_column_idx) |col_idx| {
+                if (col_idx < fields.items.len) {
+                    const field_value = fields.items[col_idx];
+                    if (comp.numeric_value) |threshold| {
+                        const val = std.fmt.parseFloat(f64, field_value) catch return;
+                        const matches = switch (comp.operator) {
+                            .equal => val == threshold,
+                            .not_equal => val != threshold,
+                            .greater => val > threshold,
+                            .greater_equal => val >= threshold,
+                            .less => val < threshold,
+                            .less_equal => val <= threshold,
+                            .like => parser.matchLike(field_value, comp.value),
+                            .ilike => parser.matchILike(field_value, comp.value),
+                            .between, .is_null, .is_not_null => parser.compareValues(comp, field_value),
+                        };
+                        if (!matches) return;
+                    } else {
+                        if (!parser.compareValues(comp, field_value)) return;
+                    }
+                } else return;
+            } else {
+                if (!parser.evaluateDirect(expr, fields.items, ctx.lower_header)) return;
+            }
+        } else {
+            if (!parser.evaluateDirect(expr, fields.items, ctx.lower_header)) return;
+        }
+    }
+
+    if (ctx.use_parallel_output) {
+        if (ctx.format == .csv) {
+            for (ctx.output_indices, 0..) |idx, j| {
+                if (j > 0) try ctx.output_buf.append(ctx.allocator, ctx.delimiter);
+                const value = if (idx < fields.items.len) fields.items[idx] else "";
+                var needs_quote = false;
+                for (value) |c| {
+                    if (c == ctx.delimiter or c == '"' or c == '\r' or c == '\n') {
+                        needs_quote = true;
+                        break;
+                    }
+                }
+                if (needs_quote) {
+                    try ctx.output_buf.append(ctx.allocator, '"');
+                    for (value) |c| {
+                        if (c == '"') try ctx.output_buf.append(ctx.allocator, '"');
+                        try ctx.output_buf.append(ctx.allocator, c);
+                    }
+                    try ctx.output_buf.append(ctx.allocator, '"');
+                } else {
+                    try ctx.output_buf.appendSlice(ctx.allocator, value);
+                }
+            }
+            try ctx.output_buf.append(ctx.allocator, '\n');
+        } else {
+            const is_jsonl = ctx.format == .jsonl;
+            if (ctx.output_buf.items.len > 0 and !is_jsonl) {
+                try ctx.output_buf.appendSlice(ctx.allocator, ",\n");
+            }
+            try ctx.output_buf.append(ctx.allocator, '{');
+            for (ctx.output_indices, 0..) |idx, j| {
+                if (j > 0) try ctx.output_buf.append(ctx.allocator, ',');
+                try ctx.output_buf.appendSlice(ctx.allocator, ctx.key_fragments[j]);
+                const value = if (idx < fields.items.len) fields.items[idx] else "";
+                if (csv.isJsonNumber(value)) {
+                    try ctx.output_buf.appendSlice(ctx.allocator, value);
+                } else {
+                    try ctx.output_buf.append(ctx.allocator, '"');
+                    try csv.appendJsonEscapedToList(&ctx.output_buf, ctx.allocator, value);
+                    try ctx.output_buf.append(ctx.allocator, '"');
+                }
+            }
+            try ctx.output_buf.append(ctx.allocator, '}');
+            if (is_jsonl) try ctx.output_buf.append(ctx.allocator, '\n');
+        }
+    } else {
+        // mmap path: build row from slices pointing into mmap data (valid until munmap)
+        var output_row = try ctx.allocator.alloc([]const u8, ctx.output_indices.len);
+        for (ctx.output_indices, 0..) |idx, j| {
+            output_row[j] = if (idx < fields.items.len) fields.items[idx] else "";
+        }
+        try ctx.result.append(ctx.allocator, output_row);
+    }
+}
+
+fn processChunk(ctx: *WorkerContext) !void {
     var arena = std.heap.ArenaAllocator.init(ctx.allocator);
     defer arena.deinit();
     const arena_alloc = arena.allocator();
 
-    // Preallocate fields array (assume max 20 columns)
     var fields = try std.ArrayList([]const u8).initCapacity(arena_alloc, 20);
 
-    var line_start: usize = 0;
-    while (line_start < chunk_data.len) {
-        const remaining = chunk_data[line_start..];
-        const line_end = std.mem.indexOfScalar(u8, remaining, '\n') orelse chunk_data.len - line_start;
+    if (ctx.use_parallel_output) {
+        // pread path: each worker opens its own file descriptor and issues independent
+        // pread calls. Avoids mmap page-fault serialization on macOS for large files —
+        // concurrent pread calls on the same file hit separate kernel I/O channels,
+        // letting all cores read in parallel instead of queuing at the page-fault handler.
+        const file = try std.fs.cwd().openFile(ctx.file_path, .{});
+        defer file.close();
 
-        var line = remaining[0..line_end];
-        // Trim \r if present
-        if (line.len > 0 and line[line.len - 1] == '\r') {
-            line = line[0 .. line.len - 1];
-        }
+        const IO_BUF: usize = 2 * 1024 * 1024;
+        const io_buf = try arena_alloc.alloc(u8, IO_BUF);
+        var seam_buf = std.ArrayListUnmanaged(u8){};
+        var combined_buf = std.ArrayListUnmanaged(u8){};
 
-        if (line.len > 0) {
-            // Reset for reuse
-            fields.clearRetainingCapacity();
+        var file_pos: usize = ctx.chunk.start;
+        while (file_pos < ctx.chunk.end) {
+            const to_read = @min(IO_BUF, ctx.chunk.end - file_pos);
+            const n = try std.posix.pread(file.handle, io_buf[0..to_read], @intCast(file_pos));
+            if (n == 0) break;
+            file_pos += n;
 
-            // SIMD-accelerated CSV field parsing
-            try simd.parseCSVFields(line, &fields, arena_alloc, ctx.delimiter);
-
-            // Fast WHERE evaluation using direct index lookup (avoid HashMap!)
-            if (ctx.query.where_expr) |expr| {
-                if (expr == .comparison) {
-                    const comp = expr.comparison;
-
-                    // Direct column access by index
-                    if (ctx.where_column_idx) |col_idx| {
-                        if (col_idx < fields.items.len) {
-                            const field_value = fields.items[col_idx];
-
-                            // Fast numeric comparison
-                            if (comp.numeric_value) |threshold| {
-                                const val = std.fmt.parseFloat(f64, field_value) catch {
-                                    line_start += line_end + 1;
-                                    continue;
-                                };
-
-                                const matches = switch (comp.operator) {
-                                    .equal => val == threshold,
-                                    .not_equal => val != threshold,
-                                    .greater => val > threshold,
-                                    .greater_equal => val >= threshold,
-                                    .less => val < threshold,
-                                    .less_equal => val <= threshold,
-                                    .like => parser.matchLike(field_value, comp.value),
-                                    .ilike => parser.matchILike(field_value, comp.value),
-                                    .between, .is_null, .is_not_null => parser.compareValues(comp, field_value),
-                                };
-
-                                if (!matches) {
-                                    line_start += line_end + 1;
-                                    continue;
-                                }
-                            } else {
-                                // Delegate to compareValues which handles IN, BETWEEN,
-                                // IS NULL/NOT NULL, LIKE, ILIKE, and normal comparisons.
-                                if (!parser.compareValues(comp, field_value)) {
-                                    line_start += line_end + 1;
-                                    continue;
-                                }
-                            }
-                        } else {
-                            line_start += line_end + 1;
-                            continue;
-                        }
-                    } else {
-                        // Complex WHERE (AND/OR/NOT): evaluate directly, no per-row HashMap
-                        if (!parser.evaluateDirect(expr, fields.items, ctx.lower_header)) {
-                            line_start += line_end + 1;
-                            continue;
-                        }
-                    }
+            var scan: usize = 0;
+            while (scan < n) {
+                const nl = std.mem.indexOfScalarPos(u8, io_buf, scan, '\n') orelse {
+                    try seam_buf.appendSlice(arena_alloc, io_buf[scan..n]);
+                    break;
+                };
+                var line: []const u8 = undefined;
+                if (seam_buf.items.len > 0) {
+                    combined_buf.clearRetainingCapacity();
+                    try combined_buf.appendSlice(arena_alloc, seam_buf.items);
+                    try combined_buf.appendSlice(arena_alloc, io_buf[scan..nl]);
+                    seam_buf.clearRetainingCapacity();
+                    line = combined_buf.items;
                 } else {
-                    // Complex expression (AND/OR/NOT): evaluate directly, no per-row HashMap
-                    if (!parser.evaluateDirect(expr, fields.items, ctx.lower_header)) {
-                        line_start += line_end + 1;
-                        continue;
-                    }
+                    line = io_buf[scan..nl];
                 }
-            }
-
-            if (ctx.use_parallel_output) {
-                if (ctx.format == .csv) {
-                    // Fast parallel CSV serialization
-                    for (ctx.output_indices, 0..) |idx, j| {
-                        if (j > 0) try ctx.output_buf.append(ctx.allocator, ctx.delimiter);
-                        const value = if (idx < fields.items.len) fields.items[idx] else "";
-                        // Check if quoting is needed
-                        var needs_quote = false;
-                        for (value) |c| {
-                            if (c == ctx.delimiter or c == '"' or c == '\r' or c == '\n') {
-                                needs_quote = true;
-                                break;
-                            }
-                        }
-                        if (needs_quote) {
-                            try ctx.output_buf.append(ctx.allocator, '"');
-                            for (value) |c| {
-                                if (c == '"') try ctx.output_buf.append(ctx.allocator, '"');
-                                try ctx.output_buf.append(ctx.allocator, c);
-                            }
-                            try ctx.output_buf.append(ctx.allocator, '"');
-                        } else {
-                            try ctx.output_buf.appendSlice(ctx.allocator, value);
-                        }
-                    }
-                    try ctx.output_buf.append(ctx.allocator, '\n');
-                } else {
-                    // Serialize directly into the per-thread JSON buffer (no heap alloc per row)
-                    const is_jsonl = ctx.format == .jsonl;
-                    if (ctx.output_buf.items.len > 0 and !is_jsonl) {
-                        try ctx.output_buf.appendSlice(ctx.allocator, ",\n");
-                    }
-                    try ctx.output_buf.append(ctx.allocator, '{');
-                    for (ctx.output_indices, 0..) |idx, j| {
-                        if (j > 0) try ctx.output_buf.append(ctx.allocator, ',');
-                        try ctx.output_buf.appendSlice(ctx.allocator, ctx.key_fragments[j]);
-                        const value = if (idx < fields.items.len) fields.items[idx] else "";
-                        if (csv.isJsonNumber(value)) {
-                            try ctx.output_buf.appendSlice(ctx.allocator, value);
-                        } else {
-                            try ctx.output_buf.append(ctx.allocator, '"');
-                            try csv.appendJsonEscapedToList(&ctx.output_buf, ctx.allocator, value);
-                            try ctx.output_buf.append(ctx.allocator, '"');
-                        }
-                    }
-                    try ctx.output_buf.append(ctx.allocator, '}');
-                    if (is_jsonl) try ctx.output_buf.append(ctx.allocator, '\n');
-                }
-            } else {
-                // CSV mode (or JSON with LIMIT): build zero-copy output row slices into mmap data
-                var output_row = try ctx.allocator.alloc([]const u8, ctx.output_indices.len);
-                for (ctx.output_indices, 0..) |idx, j| {
-                    output_row[j] = if (idx < fields.items.len) fields.items[idx] else "";
-                }
-                try ctx.result.append(ctx.allocator, output_row);
+                if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
+                scan = nl + 1;
+                if (line.len == 0) continue;
+                try processOneLine(ctx, arena_alloc, &fields, line);
             }
         }
-
-        line_start += line_end + 1;
+        // Flush any partial line in the seam buffer (last line without trailing newline)
+        if (seam_buf.items.len > 0) {
+            var line: []const u8 = seam_buf.items;
+            if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
+            if (line.len > 0) try processOneLine(ctx, arena_alloc, &fields, line);
+        }
+    } else {
+        // mmap path: for LIMIT/DISTINCT collect-rows queries.
+        // Field slices point into the mmap'd data and remain valid until munmap (after thread join).
+        const chunk_data = ctx.data[ctx.chunk.start..ctx.chunk.end];
+        var line_start: usize = 0;
+        while (line_start < chunk_data.len) {
+            const remaining = chunk_data[line_start..];
+            const line_end = std.mem.indexOfScalar(u8, remaining, '\n') orelse chunk_data.len - line_start;
+            var line = remaining[0..line_end];
+            if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
+            if (line.len > 0) try processOneLine(ctx, arena_alloc, &fields, line);
+            line_start += line_end + 1;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Replaces mmap-based parallel I/O with `pread` across all three worker types, eliminating macOS page-fault serialization on large files (30GB+). Also adds zigtable integration for pretty terminal output.

## Changes

### pread parallel I/O (3 phases)
- **`src/engine.zig`** — `gbWorkerScan` and `scalarProcessChunk` rewritten with pread+seam loop (2MB IO_BUF per worker)
- **`src/parallel_mmap.zig`** — `processChunk` uses pread for `use_parallel_output=true` path; thread cap removed (`@min(num_cores, 8)` → `num_cores`)
- mmap kept only for header parsing, chunk boundary calculation, and LIMIT/DISTINCT collect path (field slices must stay valid)

### zigtable terminal output
- **`src/options.zig`** — `TableMode` enum (`.auto`, `.on`, `.off`)
- **`src/main.zig`** — auto-TTY detection via `std.posix.isatty`; `--table` / `--no-table` flags; `renderTableOutput()` engine→tmpfile→CSV parse→zigtable render
- **`build.zig` / `build.zig.zon`** — zigtable v0.1.0 dependency

## Benchmarks

### 30GB file (6-core M-series)
| Tool | Wall time | CPU |
|------|-----------|-----|
| csvql | **6.1s** | 656% |
| DuckDB | 14.4s | 909% |

**2.35x faster than DuckDB** on 30GB GROUP BY.

### 1M rows / 35MB (`large_test.csv`)
- Aggregates / GROUP BY / DISTINCT: **9–11x faster**
- LIKE queries: **18–80x faster**
- Output formats: **7.3–7.6x faster**
- JOINs: **2.5–18.5x faster**