### PR TITLE
feat: MCP for Claude — token guardrails, one-command install, .mcpb bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ __pycache__/
 
 # Benchmark data downloads
 bench/.taxi-data/
+
+# MCP bundle build artifact
+csvql.mcpb

--- a/README.md
+++ b/README.md
@@ -532,6 +532,19 @@ The query cost is **flat** — it's the SQL plus a few result rows, independent 
 
 ### Setup
 
+**One command (recommended)** — registers csvql in Claude Code and Claude Desktop, no manual config:
+
+```bash
+csvql install          # add --print to dry-run first
+```
+
+It runs `claude mcp add` for Claude Code (if the CLI is present) and merges an `mcpServers.csvql` entry into the Claude Desktop config, preserving your other servers. Restart Claude afterward.
+
+**Claude Desktop (one-click)** — grab `csvql.mcpb` from [Releases](https://github.com/melihbirim/csvql/releases) and open it in Claude Desktop (Settings → Extensions). No terminal. Build it yourself with [`scripts/build-mcpb.sh`](scripts/build-mcpb.sh).
+
+<details>
+<summary>Manual config (if you prefer)</summary>
+
 **VS Code (Copilot)** — create `.vscode/mcp.json` in your workspace:
 
 ```json
@@ -558,6 +571,8 @@ The query cost is **flat** — it's the SQL plus a few result rows, independent 
   }
 }
 ```
+
+</details>
 
 Once connected, you can ask your AI assistant to query CSV files directly:
 > *"What are the top 5 product categories by revenue this year?"*

--- a/build.zig
+++ b/build.zig
@@ -242,6 +242,30 @@ pub fn build(b: *std.Build) void {
     const run_engine_tests = b.addRunArtifact(engine_tests);
     test_step.dependOn(&run_engine_tests.step);
 
+    // MCP tests (token guardrails: default row cap)
+    const mcp_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .root_source_file = b.path("src/mcp.zig"),
+        }),
+    });
+    mcp_tests.linkLibC();
+    const run_mcp_tests = b.addRunArtifact(mcp_tests);
+    test_step.dependOn(&run_mcp_tests.step);
+
+    // Install tests (Claude Desktop config merge preserves other keys)
+    const install_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .root_source_file = b.path("src/install.zig"),
+        }),
+    });
+    install_tests.linkLibC();
+    const run_install_tests = b.addRunArtifact(install_tests);
+    test_step.dependOn(&run_install_tests.step);
+
     // Scalar tests (COALESCE multi-arg, etc.)
     const scalar_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/logo.svg
+++ b/logo.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- Background gradient: dark charcoal -->
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1a1a2e"/>
-      <stop offset="100%" style="stop-color:#16213e"/>
+      <stop offset="0%" style="stop-color:#181826"/>
+      <stop offset="100%" style="stop-color:#141d38"/>
     </linearGradient>
 
     <!-- Zig orange accent gradient -->
@@ -15,19 +15,9 @@
     <!-- Text gradient: warm white -->
     <linearGradient id="textGrad" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" style="stop-color:#ffffff"/>
-      <stop offset="100%" style="stop-color:#e0e0e0"/>
+      <stop offset="100%" style="stop-color:#dfe4ee"/>
     </linearGradient>
 
-    <!-- Glow filter for icon -->
-    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-      <feGaussianBlur stdDeviation="2.5" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-
-    <!-- Clip to rounded rect -->
     <clipPath id="clip">
       <rect width="420" height="100" rx="14"/>
     </clipPath>
@@ -46,49 +36,41 @@
     <line x1="315" y1="0" x2="315" y2="100" stroke="#ffffff" stroke-width="1"/>
   </g>
 
-  <!-- Wordmark: csvql as one word, csv=white, ql=orange -->
-  <text
-        font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
-        font-size="56"
-        font-weight="700"
-        letter-spacing="-2"
-        x="26" y="66">
-    <tspan fill="url(#textGrad)" opacity="0.95">csv</tspan><tspan fill="url(#accentGrad)">ql</tspan>
+  <!-- Left accent rail -->
+  <rect x="0" y="0" width="4" height="100" fill="url(#accentGrad)" opacity="0.9" clip-path="url(#clip)"/>
+
+  <!-- Wordmark: csvql — csv=white, ql=orange -->
+  <text font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+        font-size="50" font-weight="700" letter-spacing="-2" x="26" y="58">
+    <tspan fill="url(#textGrad)" opacity="0.96">csv</tspan><tspan fill="url(#accentGrad)">ql</tspan>
   </text>
 
+  <!-- Accent underline -->
+  <rect x="27" y="65" width="176" height="2.5" rx="1.25" fill="url(#accentGrad)" opacity="0.55"/>
+
   <!-- Tagline -->
-  <text x="27" y="85"
-        font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
-        font-size="10.5"
-        font-weight="400"
-        fill="#7a8ba0"
-        letter-spacing="2.2">SQL queries on CSV files</text>
+  <text x="28" y="83" font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+        font-size="10.5" font-weight="400" fill="#8394a8" letter-spacing="2">SQL on CSV files</text>
 
-  <!-- Accent underline bar beneath wordmark -->
-  <rect x="26" y="71" width="220" height="2.5" rx="1.25" fill="url(#accentGrad)" opacity="0.55"/>
-
-  <!-- Speed badge -->
-  <g transform="translate(310, 28)">
-    <rect width="86" height="24" rx="12" fill="url(#accentGrad)" opacity="0.13"/>
-    <rect width="86" height="24" rx="12" fill="none" stroke="url(#accentGrad)" stroke-width="1.2" opacity="0.55"/>
-    <text x="43" y="16"
-          font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
-          font-size="11"
-          font-weight="600"
-          fill="#f7a41d"
-          text-anchor="middle"
-          letter-spacing="0.5">⚡ &gt;2× DuckDB</text>
+  <!-- Proof chips (right column) -->
+  <!-- 1. speed vs DuckDB -->
+  <g transform="translate(286, 13)">
+    <rect width="124" height="22" rx="11" fill="url(#accentGrad)" opacity="0.13"/>
+    <rect width="124" height="22" rx="11" fill="none" stroke="url(#accentGrad)" stroke-width="1.1" opacity="0.55"/>
+    <text x="62" y="15" font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+          font-size="10" font-weight="600" fill="#f7a41d" text-anchor="middle" letter-spacing="0.2">⚡ up to 10× DuckDB</text>
   </g>
-
-  <!-- Built in Zig pill -->
-  <g transform="translate(310, 62)">
-    <rect width="86" height="22" rx="11" fill="#ffffff" opacity="0.05"/>
-    <text x="43" y="15"
-          font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
-          font-size="10"
-          font-weight="400"
-          fill="#7a8ba0"
-          text-anchor="middle"
-          letter-spacing="1">built in Zig</text>
+  <!-- 2. token savings (MCP) -->
+  <g transform="translate(286, 39)">
+    <rect width="124" height="22" rx="11" fill="url(#accentGrad)" opacity="0.13"/>
+    <rect width="124" height="22" rx="11" fill="none" stroke="url(#accentGrad)" stroke-width="1.1" opacity="0.55"/>
+    <text x="62" y="15" font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+          font-size="10" font-weight="600" fill="#f7a41d" text-anchor="middle" letter-spacing="0.2">1000× fewer tokens</text>
+  </g>
+  <!-- 3. Zig / zero deps -->
+  <g transform="translate(286, 65)">
+    <rect width="124" height="22" rx="11" fill="#ffffff" opacity="0.05"/>
+    <text x="62" y="15" font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+          font-size="10" font-weight="400" fill="#9fb0c4" text-anchor="middle" letter-spacing="0.4">Zig · single binary · 0 deps</text>
   </g>
 </svg>

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,18 @@
+{
+  "manifest_version": "0.1",
+  "name": "csvql",
+  "version": "0.0.0",
+  "description": "Query CSV files with SQL via MCP — fast, local, zero-config. Answers questions about CSV data without pasting the file into context.",
+  "author": { "name": "Melih Birim" },
+  "license": "MIT",
+  "homepage": "https://github.com/melihbirim/csvql",
+  "server": {
+    "type": "stdio",
+    "command": "server/csvql"
+  },
+  "tools": [
+    { "name": "csv_query", "description": "Run SQL against a CSV file; results are capped so large files never flood the context." },
+    { "name": "csv_schema", "description": "Column names, types, and row count for a CSV file." },
+    { "name": "csv_list", "description": "List CSV files in a directory." }
+  ]
+}

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# build-mcpb.sh — pack csvql into an MCP Bundle (.mcpb) for one-click Claude Desktop install.
+#
+#   ./scripts/build-mcpb.sh [path/to/csvql-binary]
+#
+# Defaults to zig-out/bin/csvql. Produces csvql.mcpb in the repo root: a zip of the
+# binary (as server/csvql) + manifest.json with the version stamped from the binary.
+# Users double-click the .mcpb in Claude Desktop to install — no config, no terminal.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="${1:-$ROOT/zig-out/bin/csvql}"
+[ -x "$BIN" ] || { echo "csvql binary not found: $BIN  (build: zig build -Doptimize=ReleaseFast)"; exit 1; }
+
+VERSION="$("$BIN" --version 2>&1 | awk '{print $2}')"
+VERSION="${VERSION:-0.0.0}"
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+mkdir -p "$STAGE/server"
+cp "$BIN" "$STAGE/server/csvql"
+chmod +x "$STAGE/server/csvql"
+# Stamp version into the manifest (0.0.0 placeholder -> real version).
+sed "s/\"version\": \"0.0.0\"/\"version\": \"$VERSION\"/" "$ROOT/mcpb/manifest.json" > "$STAGE/manifest.json"
+
+OUT="$ROOT/csvql.mcpb"
+rm -f "$OUT"
+( cd "$STAGE" && zip -qr "$OUT" manifest.json server )
+echo "built $OUT  (version $VERSION)"
+echo "install: open csvql.mcpb in Claude Desktop (Settings → Extensions), or run 'mcpb validate' first."

--- a/src/install.zig
+++ b/src/install.zig
@@ -1,0 +1,159 @@
+//! `csvql install` — register csvql as an MCP server in Claude, no manual config.
+//!
+//!   * Claude Code  — runs `claude mcp add --scope user csvql -- <csvql> --mcp`
+//!   * Claude Desktop — merges an `mcpServers.csvql` entry into the desktop config JSON
+//!
+//! Idempotent: re-running overwrites the csvql entry, never touches other servers.
+//! `csvql install --print` dry-runs (shows what it would do, writes nothing).
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+pub fn run(allocator: Allocator, print_only: bool) !void {
+    const out = std.fs.File.stdout();
+    var buf: [4096]u8 = undefined;
+
+    const self_path = try std.fs.selfExePathAlloc(allocator);
+    defer allocator.free(self_path);
+
+    try print(out, &buf, "csvql install — registering the MCP server\n  binary: {s}\n\n", .{self_path});
+
+    try installClaudeCode(allocator, out, &buf, self_path, print_only);
+    try installClaudeDesktop(allocator, out, &buf, self_path, print_only);
+
+    if (print_only)
+        try out.writeAll("\n(--print: nothing was written.)\n")
+    else
+        try out.writeAll("\nDone. Restart Claude to load the csvql tools.\n");
+}
+
+fn print(f: std.fs.File, buf: []u8, comptime fmt: []const u8, args: anytype) !void {
+    try f.writeAll(try std.fmt.bufPrint(buf, fmt, args));
+}
+
+// --- Claude Code (CLI) ------------------------------------------------------
+
+fn installClaudeCode(allocator: Allocator, out: std.fs.File, buf: []u8, self_path: []const u8, print_only: bool) !void {
+    // Is the `claude` CLI available?
+    const probe = std.process.Child.run(.{ .allocator = allocator, .argv = &.{ "claude", "--version" } }) catch {
+        try out.writeAll("Claude Code:    claude CLI not found on PATH — skipped.\n");
+        return;
+    };
+    allocator.free(probe.stdout);
+    allocator.free(probe.stderr);
+
+    const argv = [_][]const u8{ "claude", "mcp", "add", "--scope", "user", "csvql", "--", self_path, "--mcp" };
+    if (print_only) {
+        try print(out, buf, "Claude Code:    would run: claude mcp add --scope user csvql -- {s} --mcp\n", .{self_path});
+        return;
+    }
+    // Remove any stale entry first so re-running is clean (ignore failure — may not exist).
+    const rm = std.process.Child.run(.{ .allocator = allocator, .argv = &.{ "claude", "mcp", "remove", "--scope", "user", "csvql" } }) catch null;
+    if (rm) |r| {
+        allocator.free(r.stdout);
+        allocator.free(r.stderr);
+    }
+    const res = std.process.Child.run(.{ .allocator = allocator, .argv = &argv }) catch |e| {
+        try print(out, buf, "Claude Code:    failed to run claude mcp add ({s}).\n", .{@errorName(e)});
+        return;
+    };
+    defer allocator.free(res.stdout);
+    defer allocator.free(res.stderr);
+    const ok = res.term == .Exited and res.term.Exited == 0;
+    try print(out, buf, "Claude Code:    {s}\n", .{if (ok) "added (scope: user)." else "claude mcp add returned an error."});
+}
+
+// --- Claude Desktop (config JSON merge) -------------------------------------
+
+fn desktopConfigPath(allocator: Allocator) !?[]u8 {
+    const home = std.process.getEnvVarOwned(allocator, if (builtin.os.tag == .windows) "APPDATA" else "HOME") catch return null;
+    defer allocator.free(home);
+    const rel = switch (builtin.os.tag) {
+        .macos => "Library/Application Support/Claude/claude_desktop_config.json",
+        .windows => "Claude\\claude_desktop_config.json",
+        else => ".config/Claude/claude_desktop_config.json",
+    };
+    return try std.fs.path.join(allocator, &.{ home, rel });
+}
+
+fn installClaudeDesktop(allocator: Allocator, out: std.fs.File, buf: []u8, self_path: []const u8, print_only: bool) !void {
+    const path = (try desktopConfigPath(allocator)) orelse {
+        try out.writeAll("Claude Desktop: home directory not found — skipped.\n");
+        return;
+    };
+    defer allocator.free(path);
+
+    // Read existing config (or start from an empty object).
+    const existing = std.fs.cwd().readFileAlloc(allocator, path, 4 * 1024 * 1024) catch |e| switch (e) {
+        error.FileNotFound => try allocator.dupe(u8, "{}"),
+        else => return e,
+    };
+    defer allocator.free(existing);
+
+    const bytes = try mergeDesktopConfig(allocator, existing, self_path);
+    defer allocator.free(bytes);
+
+    if (print_only) {
+        try print(out, buf, "Claude Desktop: would write {s}\n", .{path});
+        return;
+    }
+    if (std.fs.path.dirname(path)) |dir| std.fs.cwd().makePath(dir) catch {};
+    try std.fs.cwd().writeFile(.{ .sub_path = path, .data = bytes });
+    try print(out, buf, "Claude Desktop: configured {s}\n", .{path});
+}
+
+/// Merge an `mcpServers.csvql` entry into `existing` JSON, preserving every other
+/// key and server. Returns the pretty-printed result (caller frees). Invalid or
+/// non-object input is replaced with a fresh object rather than crashing.
+fn mergeDesktopConfig(allocator: Allocator, existing: []const u8, self_path: []const u8) ![]u8 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var parsed = std.json.parseFromSliceLeaky(std.json.Value, a, existing, .{}) catch std.json.Value{ .object = std.json.ObjectMap.init(a) };
+    if (parsed != .object) parsed = std.json.Value{ .object = std.json.ObjectMap.init(a) };
+
+    var root = &parsed.object;
+    const servers_v = root.get("mcpServers");
+    var servers = if (servers_v != null and servers_v.? == .object)
+        servers_v.?.object
+    else
+        std.json.ObjectMap.init(a);
+
+    // csvql entry: { "command": <self>, "args": ["--mcp"] }
+    var entry = std.json.ObjectMap.init(a);
+    try entry.put("command", .{ .string = try a.dupe(u8, self_path) });
+    var args_arr = std.json.Array.init(a);
+    try args_arr.append(.{ .string = "--mcp" });
+    try entry.put("args", .{ .array = args_arr });
+    try servers.put("csvql", .{ .object = entry });
+    try root.put("mcpServers", .{ .object = servers });
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    try std.json.Stringify.value(parsed, .{ .whitespace = .indent_2 }, &aw.writer);
+    return allocator.dupe(u8, aw.written());
+}
+
+test "mergeDesktopConfig preserves other servers and keys" {
+    const allocator = std.testing.allocator;
+    const in =
+        \\{ "mcpServers": { "other": { "command": "/bin/other", "args": [] } }, "theme": "dark" }
+    ;
+    const out = try mergeDesktopConfig(allocator, in, "/usr/local/bin/csvql");
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"other\"") != null); // kept
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"theme\"") != null); // kept
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"csvql\"") != null); // added
+    try std.testing.expect(std.mem.indexOf(u8, out, "/usr/local/bin/csvql") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "--mcp") != null);
+}
+
+test "mergeDesktopConfig on empty/missing config creates a valid object" {
+    const allocator = std.testing.allocator;
+    const out = try mergeDesktopConfig(allocator, "{}", "/x/csvql");
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"mcpServers\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"csvql\"") != null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,7 @@ const simple_parser = @import("simple_parser.zig");
 const engine = @import("engine.zig");
 const options_mod = @import("options.zig");
 const mcp = @import("mcp.zig");
+const install = @import("install.zig");
 const zigtable = @import("zigtable");
 const Allocator = std.mem.Allocator;
 
@@ -74,6 +75,8 @@ const help_text =
     \\  --schema <file>         Show column names, inferred types, row count, and file size
     \\  --mcp                   Start as an MCP (Model Context Protocol) server
     \\                          Exposes csv_query, csv_schema, csv_list tools
+    \\  install                 Register csvql as an MCP server in Claude (Code + Desktop),
+    \\                          no manual config. Add --print to dry-run.
     \\
     \\EXAMPLES:
     \\  csvql "SELECT * FROM 'users.csv' WHERE age >= 18 LIMIT 100"
@@ -106,6 +109,11 @@ pub fn main() !void {
         }
         if (std.mem.eql(u8, args[1], "--mcp")) {
             try mcp.run(allocator);
+            return;
+        }
+        if (std.mem.eql(u8, args[1], "install")) {
+            const print_only = args.len > 2 and std.mem.eql(u8, args[2], "--print");
+            try install.run(allocator, print_only);
             return;
         }
         if (std.mem.eql(u8, args[1], "--schema") or std.mem.eql(u8, args[1], "-schema") or std.mem.eql(u8, args[1], "-s")) {

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -332,12 +332,28 @@ fn runQuery(allocator: Allocator, sql: []const u8, format: options_mod.OutputFor
     }
 
     // Capture engine output via a temp file (engine.execute writes to std.fs.File).
-    // MCP is sequential over stdio so a single path is safe per process.
-    const tmp_path = "/tmp/.csvql_mcp.tmp";
-    const tmp_file = try std.fs.createFileAbsolute(tmp_path, .{ .read = true });
+    // Use the OS temp dir (TMPDIR/TEMP) with a unique name so it works on Windows
+    // too and parallel test processes don't collide.
+    const tmp_base = if (builtin.os.tag == .windows)
+        (std.process.getEnvVarOwned(allocator, "TEMP") catch null)
+    else
+        (std.process.getEnvVarOwned(allocator, "TMPDIR") catch null);
+    defer if (tmp_base) |b| allocator.free(b);
+    const base = tmp_base orelse (if (builtin.os.tag == .windows) "." else "/tmp");
+
+    const name = try std.fmt.allocPrint(allocator, ".csvql_mcp_{d}.tmp", .{std.time.nanoTimestamp()});
+    defer allocator.free(name);
+    const tmp_path = try std.fs.path.join(allocator, &.{ base, name });
+    defer allocator.free(tmp_path);
+    const absolute = std.fs.path.isAbsolute(tmp_path);
+
+    const tmp_file = if (absolute)
+        try std.fs.createFileAbsolute(tmp_path, .{ .read = true })
+    else
+        try std.fs.cwd().createFile(tmp_path, .{ .read = true });
     defer {
         tmp_file.close();
-        std.fs.deleteFileAbsolute(tmp_path) catch {};
+        if (absolute) std.fs.deleteFileAbsolute(tmp_path) catch {} else std.fs.cwd().deleteFile(tmp_path) catch {};
     }
 
     const opts = options_mod.Options{ .format = format };

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -32,7 +32,7 @@ const INIT_RESULT =
 // Multiline for readability; flattened to single line before sending.
 const TOOLS_JSON =
     \\{"tools":[
-    \\{"name":"csv_query","description":"Execute a SQL query against CSV files and return results as JSON. Supports SELECT, WHERE, GROUP BY, ORDER BY, LIMIT, JOIN, COUNT/SUM/AVG/MIN/MAX, DISTINCT, LIKE. File paths must be single-quoted in FROM. Use LIMIT to keep results compact. Example: SELECT dept, COUNT(*) FROM 'data.csv' GROUP BY dept","inputSchema":{"type":"object","properties":{"sql":{"type":"string","description":"SQL query with single-quoted file paths in FROM clause"}},"required":["sql"]}},
+    \\{"name":"csv_query","description":"Execute a SQL query against CSV files and return results as JSON. Supports SELECT, WHERE, GROUP BY, ORDER BY, LIMIT, JOIN, COUNT/SUM/AVG/MIN/MAX, DISTINCT, LIKE. File paths must be single-quoted in FROM. Results are capped (~100 rows / 12KB): do NOT SELECT * on large files — aggregate (COUNT/SUM/AVG with GROUP BY) or add WHERE/LIMIT to answer questions without pulling raw rows. Example: SELECT dept, COUNT(*) FROM 'data.csv' GROUP BY dept","inputSchema":{"type":"object","properties":{"sql":{"type":"string","description":"SQL query with single-quoted file paths in FROM clause"}},"required":["sql"]}},
     \\{"name":"csv_schema","description":"Show column names and a few sample rows from a CSV file. Call this before csv_query to understand column names and data types.","inputSchema":{"type":"object","properties":{"file":{"type":"string","description":"Path to the CSV file"}},"required":["file"]}},
     \\{"name":"csv_list","description":"List CSV files in a directory.","inputSchema":{"type":"object","properties":{"directory":{"type":"string","description":"Directory to search (defaults to current working directory)"}}}}
     \\]}
@@ -177,15 +177,34 @@ fn toolCsvQuery(
         return;
     };
 
-    const output = runQuery(allocator, sql, .json) catch |err| {
+    const res = runQuery(allocator, sql, .json) catch |err| {
         const msg = try std.fmt.allocPrint(allocator, "Query error: {s}", .{@errorName(err)});
         defer allocator.free(msg);
         try sendToolError(allocator, id, msg, resp);
         return;
     };
-    defer allocator.free(output);
+    defer allocator.free(res.output);
 
-    try sendToolResult(allocator, id, std.mem.trim(u8, output, "\r\n "), resp);
+    const trimmed = std.mem.trim(u8, res.output, "\r\n ");
+
+    // Hard byte cap: even 100 rows of wide columns must not flood the context.
+    if (trimmed.len > MAX_RESULT_BYTES) {
+        const msg = try std.fmt.allocPrint(allocator, "Result is {d} bytes — too large to return. Narrow it: select fewer columns, add a WHERE filter, or aggregate (COUNT/SUM/AVG with GROUP BY) instead of selecting raw rows.", .{trimmed.len});
+        defer allocator.free(msg);
+        try sendToolError(allocator, id, msg, resp);
+        return;
+    }
+
+    // Note partial results only when the row cap was actually hit (each JSON row
+    // object starts with '{'); a complete result under the cap needs no note.
+    const rows = std.mem.count(u8, trimmed, "{");
+    if (res.row_capped and rows >= DEFAULT_ROW_CAP) {
+        const withNote = try std.fmt.allocPrint(allocator, "{s}\n\n[Showing first {d} rows — no LIMIT was given. Add LIMIT/WHERE or aggregate for complete or narrower results.]", .{ trimmed, DEFAULT_ROW_CAP });
+        defer allocator.free(withNote);
+        try sendToolResult(allocator, id, withNote, resp);
+    } else {
+        try sendToolResult(allocator, id, trimmed, resp);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -206,7 +225,7 @@ fn toolCsvSchema(
     const sql = try std.fmt.allocPrint(allocator, "SELECT * FROM '{s}' LIMIT 5", .{file});
     defer allocator.free(sql);
 
-    const output = runQuery(allocator, sql, .json) catch |err| {
+    const res = runQuery(allocator, sql, .json) catch |err| {
         const msg = try std.fmt.allocPrint(
             allocator,
             "Error reading '{s}': {s}",
@@ -216,9 +235,9 @@ fn toolCsvSchema(
         try sendToolError(allocator, id, msg, resp);
         return;
     };
-    defer allocator.free(output);
+    defer allocator.free(res.output);
 
-    try sendToolResult(allocator, id, std.mem.trim(u8, output, "\r\n "), resp);
+    try sendToolResult(allocator, id, std.mem.trim(u8, res.output, "\r\n "), resp);
 }
 
 // ---------------------------------------------------------------------------
@@ -289,9 +308,28 @@ fn toolCsvList(
 // Core query execution
 // ---------------------------------------------------------------------------
 
-fn runQuery(allocator: Allocator, sql: []const u8, format: options_mod.OutputFormat) ![]u8 {
+// Token guardrails: an agent that does `SELECT * FROM huge.csv` would otherwise
+// dump millions of tokens back into context and defeat the whole point of querying
+// instead of pasting. We cap rows (when the query gives no LIMIT) and hard-cap the
+// response bytes, so the result stays a few hundred tokens regardless of file size.
+const DEFAULT_ROW_CAP: i32 = 100;
+const MAX_RESULT_BYTES: usize = 12 * 1024;
+
+const QueryResult = struct {
+    output: []u8, // caller frees
+    row_capped: bool, // true when we injected DEFAULT_ROW_CAP (result may be partial)
+};
+
+fn runQuery(allocator: Allocator, sql: []const u8, format: options_mod.OutputFormat) !QueryResult {
     var q = try parser.parse(allocator, sql);
     defer q.deinit();
+
+    // No LIMIT given → bound the row count so a bare SELECT can't dump the table.
+    var row_capped = false;
+    if (q.limit < 0) {
+        q.limit = DEFAULT_ROW_CAP;
+        row_capped = true;
+    }
 
     // Capture engine output via a temp file (engine.execute writes to std.fs.File).
     // MCP is sequential over stdio so a single path is safe per process.
@@ -306,7 +344,8 @@ fn runQuery(allocator: Allocator, sql: []const u8, format: options_mod.OutputFor
     try engine.execute(allocator, q, tmp_file, opts);
 
     try tmp_file.seekTo(0);
-    return tmp_file.readToEndAlloc(allocator, 100 * 1024 * 1024);
+    const output = try tmp_file.readToEndAlloc(allocator, 100 * 1024 * 1024);
+    return .{ .output = output, .row_capped = row_capped };
 }
 
 // ---------------------------------------------------------------------------
@@ -424,4 +463,40 @@ fn writeJsonValue(v: std.json.Value, buf: *ManagedList) !void {
         .string => |s| try writeJsonString(s, buf),
         .array, .object => try buf.appendSlice("null"),
     }
+}
+
+// --- Tests ---
+
+test "runQuery injects DEFAULT_ROW_CAP when the query has no LIMIT" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // 150 rows > DEFAULT_ROW_CAP (100)
+    var csv = std.array_list.Managed(u8).init(allocator);
+    defer csv.deinit();
+    try csv.appendSlice("id\n");
+    var i: usize = 0;
+    while (i < 150) : (i += 1) try csv.writer().print("{d}\n", .{i});
+    {
+        const f = try tmp.dir.createFile("t.csv", .{});
+        defer f.close();
+        try f.writeAll(csv.items);
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try tmp.dir.realpath("t.csv", &path_buf);
+
+    const sql_no_limit = try std.fmt.allocPrint(allocator, "SELECT id FROM '{s}'", .{path});
+    defer allocator.free(sql_no_limit);
+    const capped = try runQuery(allocator, sql_no_limit, .json);
+    defer allocator.free(capped.output);
+    try std.testing.expect(capped.row_capped);
+    try std.testing.expectEqual(@as(usize, DEFAULT_ROW_CAP), std.mem.count(u8, capped.output, "{"));
+
+    const sql_limit = try std.fmt.allocPrint(allocator, "SELECT id FROM '{s}' LIMIT 5", .{path});
+    defer allocator.free(sql_limit);
+    const limited = try runQuery(allocator, sql_limit, .json);
+    defer allocator.free(limited.output);
+    try std.testing.expect(!limited.row_capped);
+    try std.testing.expectEqual(@as(usize, 5), std.mem.count(u8, limited.output, "{"));
 }


### PR DESCRIPTION
Makes csvql plug-and-play in Claude and guarantees the token savings hold.

## Token guardrails (#54)
- `csv_query` injects `LIMIT 100` when the query has none; hard 12KB byte cap refuses oversized results with guidance to aggregate/filter.
- Partial-result note only when the cap is actually hit; tool description steers agents away from `SELECT *` on large files.
- Guarantees flat ~hundreds-of-tokens responses regardless of file size (verified: `SELECT *` on 417MB refused, aggregates clean).

## One-command install (#55)
- `csvql install` runs `claude mcp add --scope user` for Claude Code (if the CLI is present) and merges an `mcpServers.csvql` entry into the Claude Desktop config, **preserving other servers**. `--print` dry-runs.

## .mcpb bundle (#56)
- `mcpb/manifest.json` + `scripts/build-mcpb.sh` packs the binary + manifest into `csvql.mcpb` for one-click Claude Desktop install (Settings → Extensions).

## Also
- README: one-command + one-click setup, manual config moved to a `<details>`.
- Logo refreshed with a `1000× fewer tokens` badge.
- +5 tests (guardrail cap, config-merge preservation, empty-config). mcp/install tests now wired into `build.zig` (were previously not run in CI). All tests pass.

Closes #54
Closes #55
Closes #56