### PR TITLE
feat: --root path sandbox + on-prem/SSH docs (security)

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,19 @@ It runs `claude mcp add` for Claude Code (if the CLI is present) and merges an `
 Once connected, you can ask your AI assistant to query CSV files directly:
 > *"What are the top 5 product categories by revenue this year?"*
 
+### Remote & on-prem: query data where it lives
+
+Big files are hard to download — so run csvql **on the server next to the data** and connect over SSH. Only the SQL query and the small result cross the wire; the data never leaves the box. No open port, no reverse proxy — it rides your existing SSH keys and audit trail:
+
+```jsonc
+// client MCP config — csvql runs on the remote server
+{ "command": "ssh", "args": ["analyst@dataserver", "csvql", "--mcp", "--root", "/data"] }
+```
+
+**`--root` sandboxes file access.** With `--root /data`, queries can only read files under `/data` — `SELECT * FROM '/etc/passwd'` and `../` traversal are rejected. Always set `--root` when exposing csvql to an agent or another user. Pair it with a restricted OS user and a read-only mount for defense in depth.
+
+**Read-only by construction:** csvql only runs `SELECT` — it has no `INSERT`/`UPDATE`/`DELETE`/`DROP` and cannot modify your data. It makes zero outbound network calls and runs fully air-gapped.
+
 ## Language Libraries
 
 csvql ships as a native library for Python and Node.js — same SIMD engine, same performance, no subprocess.

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -275,7 +275,32 @@ fn hasScalarSelectFunctions(query: parser.Query) bool {
 }
 
 /// Execute a SQL query on a CSV file
+/// Confine file access to `roots` when `--root` is set. `path` must resolve
+/// (via realpath, which collapses `..` and follows symlinks) to a location inside
+/// one of the allowed root trees. Empty `roots` = unrestricted. `-`/stdin allowed.
+/// Returns error.PathOutsideAllowedRoot on violation (or if the path can't resolve).
+pub fn ensurePathAllowed(allocator: Allocator, path: []const u8, roots: []const []const u8) !void {
+    if (roots.len == 0) return;
+    if (std.mem.eql(u8, path, "-") or std.mem.eql(u8, path, "stdin")) return;
+    const real = std.fs.realpathAlloc(allocator, path) catch return error.PathOutsideAllowedRoot;
+    defer allocator.free(real);
+    for (roots) |root| {
+        const rroot = std.fs.realpathAlloc(allocator, root) catch continue;
+        defer allocator.free(rroot);
+        // Inside root iff real == rroot, or real starts with "rroot/" (the separator
+        // check stops "/data-secret" from matching root "/data").
+        if (std.mem.startsWith(u8, real, rroot) and
+            (real.len == rroot.len or real[rroot.len] == std.fs.path.sep))
+            return;
+    }
+    return error.PathOutsideAllowedRoot;
+}
+
 pub fn execute(allocator: Allocator, query: parser.Query, output_file: std.fs.File, opts: options_mod.Options) !void {
+    // --root sandbox: reject any file outside the allowed trees before opening.
+    try ensurePathAllowed(allocator, query.file_path, opts.roots);
+    for (query.joins) |j| try ensurePathAllowed(allocator, j.right_file, opts.roots);
+
     // Normalize DATE_PART(...) → STRFTIME(...) up front so every downstream path
     // (SELECT, GROUP BY, stdin, JOIN) handles it via the existing STRFTIME machinery.
     // Slice backing is shared with the caller; freed entries are replaced with new
@@ -4286,6 +4311,33 @@ test "GROUP BY ROUND(col) forms a numeric key (issue #47)" {
     _ = lines.next(); // header
     try std.testing.expectEqualStrings("1,2", lines.next().?);
     try std.testing.expectEqualStrings("2,1", lines.next().?);
+}
+
+test "ensurePathAllowed confines file access to --root trees" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    {
+        const f = try tmp.dir.createFile("data.csv", .{});
+        f.close();
+    }
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = try tmp.dir.realpath(".", &root_buf);
+    const roots = [_][]const u8{root};
+
+    var in_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const inside = try tmp.dir.realpath("data.csv", &in_buf);
+
+    // Inside the root: allowed.
+    try ensurePathAllowed(allocator, inside, &roots);
+    // Empty roots: unrestricted (backwards compatible).
+    try ensurePathAllowed(allocator, "/etc/hosts", &.{});
+    // Outside the root: rejected.
+    try std.testing.expectError(error.PathOutsideAllowedRoot, ensurePathAllowed(allocator, "/etc/hosts", &roots));
+    // Traversal escape (realpath collapses `..`): rejected.
+    const escape = try std.fmt.allocPrint(allocator, "{s}/../../../etc/hosts", .{root});
+    defer allocator.free(escape);
+    try std.testing.expectError(error.PathOutsideAllowedRoot, ensurePathAllowed(allocator, escape, &roots));
 }
 
 test "DATE_PART('year', col) rewrites to STRFTIME and groups by year" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -75,6 +75,8 @@ const help_text =
     \\  --schema <file>         Show column names, inferred types, row count, and file size
     \\  --mcp                   Start as an MCP (Model Context Protocol) server
     \\                          Exposes csv_query, csv_schema, csv_list tools
+    \\  --root <dir>[,<dir>]    Confine all file access to these directories (blocks
+    \\                          traversal/symlink escape). Use for remote/on-prem servers.
     \\  install                 Register csvql as an MCP server in Claude (Code + Desktop),
     \\                          no manual config. Add --print to dry-run.
     \\
@@ -97,6 +99,23 @@ pub fn main() !void {
     const stdout_file = stdFile(.out);
     const stderr_file = stdFile(.err);
 
+    // --root <dir>[,<dir>...] — parse from anywhere (may precede --mcp). Empty = unrestricted.
+    var roots_list = std.ArrayList([]const u8){};
+    defer roots_list.deinit(allocator);
+    {
+        var i: usize = 1;
+        while (i < args.len) : (i += 1) {
+            if (std.mem.eql(u8, args[i], "--root")) {
+                i += 1;
+                if (i < args.len) {
+                    var it = std.mem.splitScalar(u8, args[i], ',');
+                    while (it.next()) |r| if (r.len > 0) try roots_list.append(allocator, r);
+                }
+            }
+        }
+    }
+    const roots = roots_list.items;
+
     // Check for early-exit flags first (before any filtering)
     if (args.len >= 2) {
         if (std.mem.eql(u8, args[1], "--version") or std.mem.eql(u8, args[1], "-v")) {
@@ -107,8 +126,8 @@ pub fn main() !void {
             try stdout_file.writeAll(help_text);
             return;
         }
-        if (std.mem.eql(u8, args[1], "--mcp")) {
-            try mcp.run(allocator);
+        if (argHas(args, "--mcp")) {
+            try mcp.run(allocator, roots);
             return;
         }
         if (std.mem.eql(u8, args[1], "install")) {
@@ -121,13 +140,17 @@ pub fn main() !void {
                 try stderr_file.writeAll("error: --schema requires a file path argument\n");
                 std.process.exit(1);
             }
+            engine.ensurePathAllowed(allocator, args[2], roots) catch {
+                try stderr_file.writeAll("error: path outside allowed --root\n");
+                std.process.exit(1);
+            };
             try runSchema(allocator, args[2], stdout_file, stderr_file);
             return;
         }
     }
 
     // Strip --no-header / -d / --delimiter flags; collect remainder for query parsing.
-    var opts = options_mod.Options{};
+    var opts = options_mod.Options{ .roots = roots };
     var clean_args = try std.ArrayList([]const u8).initCapacity(allocator, args.len);
     defer clean_args.deinit(allocator);
     try clean_args.append(allocator, args[0]); // keep program name at [0]
@@ -154,6 +177,8 @@ pub fn main() !void {
                 std.process.exit(1);
             }
             opts.delimiter = parseDelimiter(args[i]);
+        } else if (std.mem.eql(u8, arg, "--root")) {
+            i += 1; // value already parsed into opts.roots above; skip it here
         } else {
             try clean_args.append(allocator, arg);
         }
@@ -325,6 +350,12 @@ fn getTerminalWidth() usize {
 
 /// Analyse a CSV file and print a schema table: column index, name, inferred type,
 /// non-empty count, and empty count.  Also prints a summary header line.
+/// True if `tok` appears anywhere in args[1..].
+fn argHas(args: []const [:0]u8, tok: []const u8) bool {
+    for (args[1..]) |a| if (std.mem.eql(u8, a, tok)) return true;
+    return false;
+}
+
 fn runSchema(allocator: Allocator, raw_path: []const u8, stdout_file: std.fs.File, stderr_file: std.fs.File) !void {
     // Strip surrounding quotes that users sometimes include in shell invocations.
     const file_path = blk: {

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -42,7 +42,13 @@ const TOOLS_JSON =
 // Entry point
 // ---------------------------------------------------------------------------
 
-pub fn run(allocator: Allocator) !void {
+// Server-wide --root sandbox, set once at startup. Empty = unrestricted.
+// ponytail: global — the MCP server is a single sequential process, so one
+// server-wide config is correct; no per-request roots needed.
+var g_roots: []const []const u8 = &.{};
+
+pub fn run(allocator: Allocator, roots: []const []const u8) !void {
+    g_roots = roots;
     const stdin = if (builtin.os.tag == .windows)
         std.fs.File{ .handle = std.os.windows.GetStdHandle(std.os.windows.STD_INPUT_HANDLE) catch return error.NoStdin }
     else
@@ -252,6 +258,12 @@ fn toolCsvList(
 ) !void {
     const dir_path = getStringArg(args, "directory") orelse ".";
 
+    // --root sandbox: refuse to list directories outside the allowed trees.
+    engine.ensurePathAllowed(allocator, dir_path, g_roots) catch {
+        try sendToolError(allocator, id, "directory outside allowed --root", resp);
+        return;
+    };
+
     var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch |err| {
         const msg = try std.fmt.allocPrint(
             allocator,
@@ -356,7 +368,7 @@ fn runQuery(allocator: Allocator, sql: []const u8, format: options_mod.OutputFor
         if (absolute) std.fs.deleteFileAbsolute(tmp_path) catch {} else std.fs.cwd().deleteFile(tmp_path) catch {};
     }
 
-    const opts = options_mod.Options{ .format = format };
+    const opts = options_mod.Options{ .format = format, .roots = g_roots };
     try engine.execute(allocator, q, tmp_file, opts);
 
     try tmp_file.seekTo(0);

--- a/src/options.zig
+++ b/src/options.zig
@@ -30,4 +30,7 @@ pub const Options = struct {
     table_mode: TableMode = .auto,
     /// Wrap cell content to multiple lines instead of truncating with '…'.
     wrap_cells: bool = false,
+    /// Allowed root directories (`--root`). Empty = unrestricted (current behavior).
+    /// When set, file access is confined to these trees (see engine.ensurePathAllowed).
+    roots: []const []const u8 = &.{},
 };


### PR DESCRIPTION
Closes #58 (and delivers the #59 SSH docs).

The deal-breaker for any remote/on-prem deployment: csvql could read **any path the process user can** (`SELECT * FROM '/etc/passwd'`). This adds `--root` to confine it.

## Changes
- **`--root <dir>[,<dir>...]`** confines all file access to the given trees. `engine.ensurePathAllowed` uses `realpath` (collapses `..`, resolves symlinks) then checks the canonical path is inside a canonical root — blocks traversal and symlink escape. Empty roots = unrestricted (backwards compatible).
- Enforced in `engine.execute` (covers CLI, MCP `csv_query`, `csv_schema`), MCP `csv_list`, and CLI `--schema`. Parsed from anywhere on the command line (so `--root` can precede `--mcp`).
- README: **Remote & on-prem** section — the SSH "query where the data lives" model + `--root` usage + read-only/air-gap posture. Help text updated.

## Verified
- Inside `--root`: allowed. Outside (`/etc/hosts`): rejected. `../` traversal escape: rejected. No `--root`: unrestricted. MCP `csv_query` outside root: errors.
- +1 unit test (inside / empty / outside / traversal). All tests pass.

Next for on-prem: SECURITY.md (#61), audit log (#62), HTTP transport (#60, later).