### PR TITLE
feat: add --threads option for parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ csvql "SELECT email FROM 'users.csv'" | wc -l
 | `--delimiter <char>` | `-d`  | Field delimiter (default `,`). Use `\t` for TSV     |
 | `--json`             |       | Output as a JSON array (`[{...}, ...]`)             |
 | `--jsonl`            |       | Output as JSONL / NDJSON (one JSON object per line) |
+| `--threads <N>`      |       | Worker threads for parallel execution; `0` uses automatic detection |
 | `--version`          | `-v`  | Show version                                        |
 | `--help`             | `-h`  | Show help                                           |
 | `--mcp`              |       | Start as an MCP server (stdio JSON-RPC transport)   |

--- a/build.zig
+++ b/build.zig
@@ -242,6 +242,17 @@ pub fn build(b: *std.Build) void {
     const run_engine_tests = b.addRunArtifact(engine_tests);
     test_step.dependOn(&run_engine_tests.step);
 
+    // Options tests (thread count configuration)
+    const options_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .root_source_file = b.path("src/options.zig"),
+        }),
+    });
+    const run_options_tests = b.addRunArtifact(options_tests);
+    test_step.dependOn(&run_options_tests.step);
+
     // MCP tests (token guardrails: default row cap)
     const mcp_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -46,12 +46,6 @@ extern fn sysctlbyname(
 /// No-op on non-macOS (conditional compile).
 extern fn pthread_set_qos_class_self_np(qos_class: u32, relative_priority: i32) c_int;
 
-/// Returns the thread count for parallel scans.
-/// Uses all logical CPUs — worker threads set QOS_CLASS_USER_INTERACTIVE to
-/// preference P-cores on Apple Silicon where that improves scheduling.
-fn getEffectiveThreadCount() usize {
-    return std.Thread.getCpuCount() catch 1;
-}
 const ArenaBuffer = arena_buffer.ArenaBuffer;
 const appendJsonStringToArena = arena_buffer.appendJsonStringToArena;
 
@@ -364,7 +358,7 @@ pub fn execute(allocator: Allocator, query: parser.Query, output_file: std.fs.Fi
             !query.distinct and
             query.limit < 0)
         {
-            const nc = getEffectiveThreadCount();
+            const nc = options_mod.effectiveThreadCount(opts);
             if (nc > 1) {
                 try executeParallelScalar(allocator, query, file_s, output_file, opts);
                 return;
@@ -383,8 +377,8 @@ pub fn execute(allocator: Allocator, query: parser.Query, output_file: std.fs.Fi
 
     // Use parallel memory-mapped I/O for large files (2+ cores, no LIMIT unless ORDER BY)
     if (file_stat.size > 10 * 1024 * 1024 and (query.limit < 0 or query.limit > 100000 or query.order_by != null)) {
-        const num_cores = try std.Thread.getCpuCount();
-        if (num_cores > 1) {
+        const num_threads = options_mod.effectiveThreadCount(opts);
+        if (num_threads > 1) {
             try parallel_mmap.executeParallelMapped(allocator, query, file, output_file, opts);
             return;
         }
@@ -1053,7 +1047,7 @@ fn executeParallelScalar(
     try writer.flush();
 
     // Split into N worker chunks aligned to line boundaries
-    const num_cores = getEffectiveThreadCount();
+    const num_cores = options_mod.effectiveThreadCount(opts);
     const n_threads = num_cores;
     const data_start = header_nl + 1;
     const data_len = data.len - data_start;
@@ -2729,7 +2723,7 @@ fn executeScalarAgg(
     var field_stk: [256][]const u8 = undefined;
 
     // -- Scan (parallel on large files, sequential on small) --
-    const num_cores_sa = getEffectiveThreadCount();
+    const num_cores_sa = options_mod.effectiveThreadCount(opts);
     if (num_cores_sa > 1 and file_size > 10 * 1024 * 1024) {
         const n_threads = num_cores_sa;
         const chunks = try splitLineChunks(data, header_nl + 1, n_threads, allocator);
@@ -3782,7 +3776,7 @@ fn executeGroupBy(
     // Each thread independently scans its chunk into its own partial_map;
     // main thread merges arithmetic results after join (O(num_groups), negligible).
     // Single-threaded fallback for small files or single-core environments.
-    const num_cores = getEffectiveThreadCount();
+    const num_cores = options_mod.effectiveThreadCount(opts);
     if (num_cores > 1 and file_size > 10 * 1024 * 1024) {
         const n_threads = num_cores;
         const chunks = try splitLineChunks(data, header_nl + 1, n_threads, allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,6 +72,7 @@ const help_text =
     \\  --table                 Always render output as a table (default: auto on TTY)
     \\  --no-table              Never render output as a table
     \\  --wrap                  Wrap long cell text across lines instead of dropping columns
+    \\  --threads <N>           Worker threads for parallel execution (0 = auto)
     \\  --schema <file>         Show column names, inferred types, row count, and file size
     \\  --mcp                   Start as an MCP (Model Context Protocol) server
     \\                          Exposes csv_query, csv_schema, csv_list tools
@@ -170,6 +171,16 @@ pub fn main() !void {
             opts.wrap_cells = true;
         } else if (std.mem.eql(u8, arg, "--no-table")) {
             opts.table_mode = .off;
+        } else if (std.mem.eql(u8, arg, "--threads")) {
+            i += 1;
+            if (i >= args.len) {
+                try stderr_file.writeAll("error: --threads requires a non-negative integer argument\n");
+                std.process.exit(1);
+            }
+            opts.threads = std.fmt.parseInt(usize, args[i], 10) catch {
+                try stderr_file.writeAll("error: --threads requires a non-negative integer argument\n");
+                std.process.exit(1);
+            };
         } else if (std.mem.eql(u8, arg, "-d") or std.mem.eql(u8, arg, "--delimiter")) {
             i += 1;
             if (i >= args.len) {

--- a/src/options.zig
+++ b/src/options.zig
@@ -41,9 +41,14 @@ pub const Options = struct {
 
 /// Resolve the configured worker count.
 /// A value of 0 preserves the current automatic CPU-count behavior.
+/// The effective value is clamped to the range 1...1024.
 pub fn effectiveThreadCount(opts: Options) usize {
-    if (opts.threads != 0) return opts.threads;
-    return std.Thread.getCpuCount() catch 1;
+    const n = if (opts.threads != 0)
+        opts.threads
+    else
+        (std.Thread.getCpuCount() catch 1);
+
+    return @max(1, @min(n, 1024));
 }
 
 test "effectiveThreadCount uses configured value" {
@@ -54,4 +59,9 @@ test "effectiveThreadCount uses configured value" {
 test "effectiveThreadCount auto-detects when threads is zero" {
     const opts = Options{};
     try std.testing.expect(effectiveThreadCount(opts) >= 1);
+}
+
+test "effectiveThreadCount caps configured value" {
+    const opts = Options{ .threads = 2_000_000 };
+    try std.testing.expectEqual(@as(usize, 1024), effectiveThreadCount(opts));
 }

--- a/src/options.zig
+++ b/src/options.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 /// Output format for query results.
 pub const OutputFormat = enum {
     /// Comma-separated values (default).
@@ -30,7 +32,26 @@ pub const Options = struct {
     table_mode: TableMode = .auto,
     /// Wrap cell content to multiple lines instead of truncating with '…'.
     wrap_cells: bool = false,
+    /// Number of worker threads. 0 = auto-detect logical CPU count.
+    threads: usize = 0,
     /// Allowed root directories (`--root`). Empty = unrestricted (current behavior).
     /// When set, file access is confined to these trees (see engine.ensurePathAllowed).
     roots: []const []const u8 = &.{},
 };
+
+/// Resolve the configured worker count.
+/// A value of 0 preserves the current automatic CPU-count behavior.
+pub fn effectiveThreadCount(opts: Options) usize {
+    if (opts.threads != 0) return opts.threads;
+    return std.Thread.getCpuCount() catch 1;
+}
+
+test "effectiveThreadCount uses configured value" {
+    const opts = Options{ .threads = 4 };
+    try std.testing.expectEqual(@as(usize, 4), effectiveThreadCount(opts));
+}
+
+test "effectiveThreadCount auto-detects when threads is zero" {
+    const opts = Options{};
+    try std.testing.expect(effectiveThreadCount(opts) >= 1);
+}

--- a/src/parallel_mmap.zig
+++ b/src/parallel_mmap.zig
@@ -196,9 +196,8 @@ pub fn executeParallelMapped(
     const data_start = header_end + 1;
     const data_len = data.len - data_start;
 
-    // Get number of threads
-    const num_cores = try std.Thread.getCpuCount();
-    const num_threads = num_cores;
+    // Resolve the requested worker count; 0 preserves automatic CPU detection.
+    const num_threads = options_mod.effectiveThreadCount(opts);
 
     // Split into chunks aligned to line boundaries
     const chunk_size = data_len / num_threads;

--- a/src/parallel_mmap.zig
+++ b/src/parallel_mmap.zig
@@ -197,7 +197,11 @@ pub fn executeParallelMapped(
     const data_len = data.len - data_start;
 
     // Resolve the requested worker count; 0 preserves automatic CPU detection.
-    const num_threads = options_mod.effectiveThreadCount(opts);
+    // Never use more workers than there are data bytes, otherwise chunk_size can become 0.
+    const num_threads = @min(
+        options_mod.effectiveThreadCount(opts),
+        @max(@as(usize, 1), data_len),
+    );
 
     // Split into chunks aligned to line boundaries
     const chunk_size = data_len / num_threads;


### PR DESCRIPTION
Closes #51

## Summary
-     Add --threads N option
- preserve current automatic CPU detection when omitted or set to `0`
- apply the configured worker count across parallel execution paths
- document the option in `--help` and README
-     Add tests and documentation.

## Validation
- `zig build test`
- `zig build`
- verified `--threads 0`, `--threads 1`, and `--threads 4`
- verified invalid and missing values exit with status 1