### PR TITLE
feat: --no-input-header for headerless CSVs (c1..cN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ csvql "SELECT email FROM 'users.csv'" | wc -l
 | Flag                 | Short | Description                                         |
 | -------------------- | ----- | --------------------------------------------------- |
 | `--no-header`        |       | Suppress header row in output                       |
+| `--no-input-header`  |       | Treat the first row as data; auto-name columns `c1`..`cN` |
 | `--delimiter <char>` | `-d`  | Field delimiter (default `,`). Use `\t` for TSV     |
 | `--json`             |       | Output as a JSON array (`[{...}, ...]`)             |
 | `--jsonl`            |       | Output as JSONL / NDJSON (one JSON object per line) |

--- a/src/csv.zig
+++ b/src/csv.zig
@@ -5,6 +5,40 @@ const options_mod = @import("options.zig");
 /// Re-export options so callers that only import csv can access Options/OutputFormat.
 pub const options = options_mod;
 
+/// Header names + where the data begins, for the mmap-based scan paths.
+/// With `--no-input-header` the first row is data and names are synthesized c1..cN;
+/// otherwise the first line is the header and data starts after it.
+pub const MmapHeader = struct {
+    names: [][]const u8, // slices into `data` (real header) or allocated "cN" (synth)
+    data_start: usize,
+    synth: bool,
+
+    pub fn deinit(self: MmapHeader, a: Allocator) void {
+        if (self.synth) for (self.names) |n| a.free(n);
+        a.free(self.names);
+    }
+};
+
+pub fn resolveMmapHeader(a: Allocator, data: []const u8, opts: options_mod.Options) !MmapHeader {
+    const nl = std.mem.indexOfScalar(u8, data, '\n') orelse return error.NoHeader;
+    var line = data[0..nl];
+    if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
+    var n: usize = 1;
+    for (line) |c| if (c == opts.delimiter) {
+        n += 1;
+    };
+    const names = try a.alloc([]const u8, n);
+    errdefer a.free(names);
+    if (opts.no_input_header) {
+        for (names, 0..) |*nm, i| nm.* = try std.fmt.allocPrint(a, "c{d}", .{i + 1});
+        return .{ .names = names, .data_start = 0, .synth = true };
+    }
+    var it = std.mem.splitScalar(u8, line, opts.delimiter);
+    var i: usize = 0;
+    while (it.next()) |col| : (i += 1) names[i] = col;
+    return .{ .names = names, .data_start = nl + 1, .synth = false };
+}
+
 /// RFC 4180 compliant CSV reader
 pub const CsvReader = struct {
     file: std.fs.File,

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -410,9 +410,25 @@ fn executeSequential(
     var writer = csv.RecordWriter.init(output_file, opts);
     defer writer.deinit();
 
-    // Read header
-    const header = try reader.readRecord() orelse return error.EmptyFile;
-    defer reader.freeRecord(header);
+    // Read row 0. Normally it's the header; with --no-input-header we synthesize
+    // c1..cN names and keep this (owned) record as the first data row.
+    const first_owned = try reader.readRecord() orelse return error.EmptyFile;
+    var synth_names: ?[][]const u8 = null;
+    var first_data: ?[]const []const u8 = null;
+    defer {
+        if (synth_names) |sn| {
+            for (sn) |s| allocator.free(s);
+            allocator.free(sn);
+        }
+        reader.freeRecord(first_owned);
+    }
+    const header: []const []const u8 = if (opts.no_input_header) blk: {
+        const names = try allocator.alloc([]const u8, first_owned.len);
+        for (names, 0..) |*nm, i| nm.* = try std.fmt.allocPrint(allocator, "c{d}", .{i + 1});
+        synth_names = names;
+        first_data = first_owned;
+        break :blk names;
+    } else first_owned;
 
     // Build column index map (case-insensitive)
     var column_map = std.StringHashMap(usize).init(allocator);
@@ -538,7 +554,13 @@ fn executeSequential(
     var scalar_arena = std.heap.ArenaAllocator.init(allocator);
     defer scalar_arena.deinit();
 
-    while (try reader.readRecordSlices()) |record| {
+    // Process the retained first data row (headerless), then stream the rest.
+    var pending_first = first_data;
+    while (true) {
+        const record = if (pending_first) |p| blk: {
+            pending_first = null;
+            break :blk p;
+        } else (try reader.readRecordSlices()) orelse break;
         // Zero-copy: record slices point into reader buffer, no freeRecord needed
         row_count += 1;
 
@@ -968,18 +990,9 @@ fn executeParallelScalar(
     defer unmapFile(allocator, data);
 
     // Parse header
-    const header_nl = std.mem.indexOfScalar(u8, data, '\n') orelse return error.NoHeader;
-    var header_line = data[0..header_nl];
-    if (header_line.len > 0 and header_line[header_line.len - 1] == '\r')
-        header_line = header_line[0 .. header_line.len - 1];
-
-    var header_list = std.ArrayListUnmanaged([]const u8){};
-    defer header_list.deinit(allocator);
-    {
-        var hi = std.mem.splitScalar(u8, header_line, opts.delimiter);
-        while (hi.next()) |col| try header_list.append(allocator, col);
-    }
-    const header = header_list.items;
+    const hinfo = try csv.resolveMmapHeader(allocator, data, opts);
+    defer hinfo.deinit(allocator);
+    const header = hinfo.names;
 
     // Build lowercase column map
     var lower_header_buf = try allocator.alloc([]u8, header.len);
@@ -1049,7 +1062,7 @@ fn executeParallelScalar(
     // Split into N worker chunks aligned to line boundaries
     const num_cores = options_mod.effectiveThreadCount(opts);
     const n_threads = num_cores;
-    const data_start = header_nl + 1;
+    const data_start = hinfo.data_start;
     const data_len = data.len - data_start;
     const chunk_size = data_len / n_threads;
 
@@ -1543,9 +1556,25 @@ fn executeFromStdin(
     var writer = csv.RecordWriter.init(output_file, opts);
     defer writer.deinit();
 
-    // Read header
-    const header = try reader.readRecord() orelse return error.EmptyFile;
-    defer reader.freeRecord(header);
+    // Read row 0. Normally it's the header; with --no-input-header we synthesize
+    // c1..cN names and keep this (owned) record as the first data row.
+    const first_owned = try reader.readRecord() orelse return error.EmptyFile;
+    var synth_names: ?[][]const u8 = null;
+    var first_data: ?[]const []const u8 = null;
+    defer {
+        if (synth_names) |sn| {
+            for (sn) |s| allocator.free(s);
+            allocator.free(sn);
+        }
+        reader.freeRecord(first_owned);
+    }
+    const header: []const []const u8 = if (opts.no_input_header) blk: {
+        const names = try allocator.alloc([]const u8, first_owned.len);
+        for (names, 0..) |*nm, i| nm.* = try std.fmt.allocPrint(allocator, "c{d}", .{i + 1});
+        synth_names = names;
+        first_data = first_owned;
+        break :blk names;
+    } else first_owned;
 
     // Build column index map (case-insensitive)
     var column_map = std.StringHashMap(usize).init(allocator);
@@ -1633,8 +1662,20 @@ fn executeFromStdin(
     // Process rows
     var rows_written: i32 = 0;
 
-    while (try reader.readRecord()) |record| {
-        defer reader.freeRecord(record);
+    // Process the retained first data row (headerless), then stream the rest.
+    // The injected first row is freed by the outer defer, not here.
+    var pending_first = first_data;
+    while (true) {
+        var owned_rec: ?[][]u8 = null;
+        const record: []const []const u8 = if (pending_first) |p| blk: {
+            pending_first = null;
+            break :blk p;
+        } else blk: {
+            const r = (try reader.readRecord()) orelse break;
+            owned_rec = r;
+            break :blk r;
+        };
+        defer if (owned_rec) |r| reader.freeRecord(r);
 
         // OPTIMIZATION: Fast WHERE evaluation using direct index lookup
         if (query.where_expr) |expr| {
@@ -2321,18 +2362,9 @@ fn executeDistinct(
     defer writer.deinit();
 
     // Header
-    const header_nl = std.mem.indexOfScalar(u8, data, '\n') orelse return error.NoHeader;
-    var header_line = data[0..header_nl];
-    if (header_line.len > 0 and header_line[header_line.len - 1] == '\r')
-        header_line = header_line[0 .. header_line.len - 1];
-
-    var header_list = std.ArrayListUnmanaged([]const u8){};
-    defer header_list.deinit(allocator);
-    {
-        var it = std.mem.splitScalar(u8, header_line, opts.delimiter);
-        while (it.next()) |col| try header_list.append(allocator, col);
-    }
-    const header = header_list.items;
+    const hinfo = try csv.resolveMmapHeader(allocator, data, opts);
+    defer hinfo.deinit(allocator);
+    const header = hinfo.names;
 
     // Build lowercase column map
     var lower_header = try allocator.alloc([]u8, header.len);
@@ -2439,7 +2471,7 @@ fn executeDistinct(
     defer key_buf.deinit(allocator);
 
     var rows_written: i32 = 0;
-    var pos: usize = header_nl + 1;
+    var pos: usize = hinfo.data_start;
 
     while (pos < data.len) {
         const line_start = pos;
@@ -2589,18 +2621,9 @@ fn executeScalarAgg(
     defer writer.deinit();
 
     // -- Header --
-    const header_nl = std.mem.indexOfScalar(u8, data, '\n') orelse return error.NoHeader;
-    var header_line = data[0..header_nl];
-    if (header_line.len > 0 and header_line[header_line.len - 1] == '\r')
-        header_line = header_line[0 .. header_line.len - 1];
-
-    var header_list = std.ArrayListUnmanaged([]const u8){};
-    defer header_list.deinit(allocator);
-    {
-        var it = std.mem.splitScalar(u8, header_line, opts.delimiter);
-        while (it.next()) |col| try header_list.append(allocator, col);
-    }
-    const header = header_list.items;
+    const hinfo = try csv.resolveMmapHeader(allocator, data, opts);
+    defer hinfo.deinit(allocator);
+    const header = hinfo.names;
 
     var lower_header = try allocator.alloc([]u8, header.len);
     defer {
@@ -2726,7 +2749,7 @@ fn executeScalarAgg(
     const num_cores_sa = options_mod.effectiveThreadCount(opts);
     if (num_cores_sa > 1 and file_size > 10 * 1024 * 1024) {
         const n_threads = num_cores_sa;
-        const chunks = try splitLineChunks(data, header_nl + 1, n_threads, allocator);
+        const chunks = try splitLineChunks(data, hinfo.data_start, n_threads, allocator);
         defer allocator.free(chunks);
 
         var thread_ctxs = try allocator.alloc(ScalarAggWorkerCtx, n_threads);
@@ -2783,7 +2806,7 @@ fn executeScalarAgg(
         }
     } else {
         // -- Sequential scan --
-        var scan_pos: usize = header_nl + 1;
+        var scan_pos: usize = hinfo.data_start;
         while (scan_pos < data.len) {
             const line_start = scan_pos;
             const nl = std.mem.indexOfScalarPos(u8, data, scan_pos, '\n');
@@ -3472,18 +3495,9 @@ fn executeGroupBy(
     defer writer.deinit();
 
     // -- Header parsing -----------------------------------------------------
-    const header_nl = std.mem.indexOfScalar(u8, data, '\n') orelse return error.NoHeader;
-    var header_line = data[0..header_nl];
-    if (header_line.len > 0 and header_line[header_line.len - 1] == '\r')
-        header_line = header_line[0 .. header_line.len - 1];
-
-    var header_list = std.ArrayListUnmanaged([]const u8){};
-    defer header_list.deinit(allocator);
-    {
-        var it = std.mem.splitScalar(u8, header_line, opts.delimiter);
-        while (it.next()) |col| try header_list.append(allocator, col);
-    }
-    const header = header_list.items;
+    const hinfo = try csv.resolveMmapHeader(allocator, data, opts);
+    defer hinfo.deinit(allocator);
+    const header = hinfo.names;
 
     var lower_header = try allocator.alloc([]u8, header.len);
     defer {
@@ -3779,7 +3793,7 @@ fn executeGroupBy(
     const num_cores = options_mod.effectiveThreadCount(opts);
     if (num_cores > 1 and file_size > 10 * 1024 * 1024) {
         const n_threads = num_cores;
-        const chunks = try splitLineChunks(data, header_nl + 1, n_threads, allocator);
+        const chunks = try splitLineChunks(data, hinfo.data_start, n_threads, allocator);
         defer allocator.free(chunks);
 
         var thread_ctxs = try allocator.alloc(GbWorkerCtx, n_threads);
@@ -3875,7 +3889,7 @@ fn executeGroupBy(
         }
     } else {
         // -- Sequential mmap scan (single-core or small file) --
-        var pos: usize = header_nl + 1;
+        var pos: usize = hinfo.data_start;
         while (pos < data.len) {
             const line_start = pos;
             const nl = std.mem.indexOfScalarPos(u8, data, pos, '\n');
@@ -4305,6 +4319,40 @@ test "GROUP BY ROUND(col) forms a numeric key (issue #47)" {
     _ = lines.next(); // header
     try std.testing.expectEqualStrings("1,2", lines.next().?);
     try std.testing.expectEqualStrings("2,1", lines.next().?);
+}
+
+test "--no-input-header: first row is data, columns named c1..cN" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // No header row. 3 data rows.
+    const data = "1,green,10\n2,yellow,20\n3,green,30\n";
+    {
+        const f = try tmp.dir.createFile("h.csv", .{});
+        defer f.close();
+        try f.writeAll(data);
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try tmp.dir.realpath("h.csv", &path_buf);
+
+    const sql = try std.fmt.allocPrint(allocator, "SELECT c2, COUNT(*) FROM '{s}' GROUP BY c2", .{path});
+    defer allocator.free(sql);
+    var query = try parser.parse(allocator, sql);
+    defer query.deinit();
+
+    const out_file = try tmp.dir.createFile("out.csv", .{ .read = true });
+    defer out_file.close();
+    try execute(allocator, query, out_file, .{ .no_input_header = true });
+
+    try out_file.seekTo(0);
+    const out = try out_file.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(out);
+
+    // Header uses synthesized name c2; row 0 counted (green=2, not 1).
+    try std.testing.expect(std.mem.indexOf(u8, out, "c2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "green,2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "yellow,1") != null);
 }
 
 test "ensurePathAllowed confines file access to --root trees" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,6 +66,7 @@ const help_text =
     \\  -h, --help              Show this help
     \\  -v, --version           Show version
     \\  --no-header             Suppress header row in output
+    \\  --no-input-header       Treat the first row as data; name columns c1..cN
     \\  -d, --delimiter <char>  Field delimiter (default: ',')  e.g. -d '\t' for TSV
     \\  --json                  Output results as a JSON array of objects
     \\  --jsonl                 Output results as newline-delimited JSON (NDJSON)
@@ -169,6 +170,8 @@ pub fn main() !void {
             opts.table_mode = .on;
         } else if (std.mem.eql(u8, arg, "--wrap")) {
             opts.wrap_cells = true;
+        } else if (std.mem.eql(u8, arg, "--no-input-header")) {
+            opts.no_input_header = true;
         } else if (std.mem.eql(u8, arg, "--no-table")) {
             opts.table_mode = .off;
         } else if (std.mem.eql(u8, arg, "--threads")) {

--- a/src/options.zig
+++ b/src/options.zig
@@ -34,6 +34,8 @@ pub const Options = struct {
     wrap_cells: bool = false,
     /// Number of worker threads. 0 = auto-detect logical CPU count.
     threads: usize = 0,
+    /// Treat the first row as data (not a header) and auto-name columns c1..cN.
+    no_input_header: bool = false,
     /// Allowed root directories (`--root`). Empty = unrestricted (current behavior).
     /// When set, file access is confined to these trees (see engine.ensurePathAllowed).
     roots: []const []const u8 = &.{},

--- a/src/parallel_mmap.zig
+++ b/src/parallel_mmap.zig
@@ -97,26 +97,16 @@ pub fn executeParallelMapped(
     const data = try mapFile(allocator, input_file, file_size);
     defer unmapFile(allocator, data);
 
-    // Find end of header line
-    const header_end = std.mem.indexOfScalar(u8, data, '\n') orelse return error.NoHeader;
-    const header_line_raw = data[0..header_end];
-    // Strip trailing \r for CRLF files
-    const header_line = if (header_line_raw.len > 0 and header_line_raw[header_line_raw.len - 1] == '\r') header_line_raw[0 .. header_line_raw.len - 1] else header_line_raw;
-
-    // Parse header
-    var header = std.ArrayList([]const u8){};
-    defer header.deinit(allocator);
-
-    var header_iter = std.mem.splitScalar(u8, header_line, opts.delimiter);
-    while (header_iter.next()) |col| {
-        try header.append(allocator, col);
-    }
+    // Resolve header (or synthesize c1..cN with --no-input-header) and data start.
+    const hinfo = try csv.resolveMmapHeader(allocator, data, opts);
+    defer hinfo.deinit(allocator);
+    const header = hinfo.names;
 
     // Build column map
     var column_map = std.StringHashMap(usize).init(allocator);
     defer column_map.deinit();
 
-    var lower_header = try allocator.alloc([]u8, header.items.len);
+    var lower_header = try allocator.alloc([]u8, header.len);
     defer {
         for (lower_header) |lower_name| {
             allocator.free(lower_name);
@@ -124,7 +114,7 @@ pub fn executeParallelMapped(
         allocator.free(lower_header);
     }
 
-    for (header.items, 0..) |col_name, idx| {
+    for (header, 0..) |col_name, idx| {
         const lower_name = try allocator.alloc(u8, col_name.len);
         _ = std.ascii.lowerString(lower_name, col_name);
         lower_header[idx] = lower_name;
@@ -136,7 +126,7 @@ pub fn executeParallelMapped(
     defer output_indices.deinit(allocator);
 
     if (query.all_columns) {
-        for (0..header.items.len) |idx| {
+        for (0..header.len) |idx| {
             try output_indices.append(allocator, idx);
         }
     } else {
@@ -163,7 +153,7 @@ pub fn executeParallelMapped(
 
     if (query.all_columns) {
         for (output_indices.items) |idx| {
-            try output_header.append(allocator, header.items[idx]);
+            try output_header.append(allocator, header[idx]);
         }
     } else {
         for (query.columns) |col| {
@@ -193,7 +183,7 @@ pub fn executeParallelMapped(
     }
 
     // Process data in parallel
-    const data_start = header_end + 1;
+    const data_start = hinfo.data_start;
     const data_len = data.len - data_start;
 
     // Resolve the requested worker count; 0 preserves automatic CPU detection.


### PR DESCRIPTION
Closes #49.

Adds `--no-input-header`: treat the first row as data and auto-name columns `c1`, `c2`, ... `cN`. For datasets that ship without a header row.

## Implementation
- `csv.resolveMmapHeader` centralizes header parsing for the five mmap scan paths (parallel scalar, distinct, scalar agg, group by, parallel_mmap) — returns synthesized `c1..cN` names and `data_start = 0` when the flag is set, otherwise the real header and `data_start` after it. Removes the duplicated inline header block from each.
- The two streaming paths (`executeSequential`, `executeFromStdin`) read row 0 as an owned record and, when headerless, retain it as the first data row instead of consuming it as a header.

## Verified
Row 0 is counted as data across every path: plain scan, `WHERE`, `GROUP BY`, `DISTINCT`, scalar aggregate, `ORDER BY`, stdin pipe, and the >10 MB parallel group-by / parallel_mmap paths (cross-checked against `awk`). +1 unit test. 132 tests pass.

## Not covered
`JOIN` still treats row 0 of each file as a header. Left as a follow-up since it uses a separate read path.