### PR TITLE
feat: --audit query log for compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ csvql "SELECT email FROM 'users.csv'" | wc -l
 | `--version`          | `-v`  | Show version                                        |
 | `--help`             | `-h`  | Show help                                           |
 | `--mcp`              |       | Start as an MCP server (stdio JSON-RPC transport)   |
+| `--root <dir>`       |       | Confine file access to a directory (repeatable via commas) |
+| `--audit <file>`     |       | Append a JSONL audit record per query (timestamp, SQL)     |
 
 ```bash
 # TSV file

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,7 @@ When running csvql on a server that an agent or remote user queries:
 * Set `--root` to the data directory so nothing else is readable.
 * Run as a dedicated, unprivileged user with a read only mount of the data.
 * Prefer the SSH access model (`ssh host csvql --mcp --root /data`). It reuses your existing SSH keys, bastion, and audit trail, and needs no open port.
+* Enable `--audit <file>` to record every query (timestamp and SQL) as JSONL for compliance and forensics.
 * If you expose an HTTP transport later, keep csvql behind a reverse proxy that terminates TLS and handles authentication.
 
 See the README section "Remote and on-prem" for the SSH setup.

--- a/build.zig
+++ b/build.zig
@@ -277,6 +277,18 @@ pub fn build(b: *std.Build) void {
     const run_install_tests = b.addRunArtifact(install_tests);
     test_step.dependOn(&run_install_tests.step);
 
+    // Audit-log tests
+    const audit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .root_source_file = b.path("src/audit.zig"),
+        }),
+    });
+    audit_tests.linkLibC();
+    const run_audit_tests = b.addRunArtifact(audit_tests);
+    test_step.dependOn(&run_audit_tests.step);
+
     // Scalar tests (COALESCE multi-arg, etc.)
     const scalar_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/src/audit.zig
+++ b/src/audit.zig
@@ -1,0 +1,65 @@
+//! Optional query audit log (`--audit <file>`). Appends one JSON object per query
+//! so on-prem operators can prove, after the fact, exactly what was queried and when.
+//! Best-effort: an audit failure never fails the query.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+/// Append a JSONL record: {"ts":<unix>,"sql":"...","rows":N,"bytes":N}.
+/// `rows`/`bytes` are optional (null when unknown, e.g. streamed CLI output).
+/// ponytail: plain append with seekFromEnd. One process/query at a time here
+/// (MCP is sequential, CLI is one query per run), so no cross-process locking.
+pub fn record(allocator: Allocator, path: []const u8, sql: []const u8, rows: ?usize, bytes: ?usize) void {
+    var line = std.ArrayList(u8){};
+    defer line.deinit(allocator);
+
+    line.appendSlice(allocator, "{\"ts\":") catch return;
+    line.writer(allocator).print("{d}", .{std.time.timestamp()}) catch return;
+    line.appendSlice(allocator, ",\"sql\":\"") catch return;
+    appendEscaped(&line, allocator, sql) catch return;
+    line.append(allocator, '"') catch return;
+    if (rows) |r| line.writer(allocator).print(",\"rows\":{d}", .{r}) catch return;
+    if (bytes) |b| line.writer(allocator).print(",\"bytes\":{d}", .{b}) catch return;
+    line.appendSlice(allocator, "}\n") catch return;
+
+    // Open or create without truncating, then append at the end.
+    const f = std.fs.cwd().createFile(path, .{ .truncate = false }) catch return;
+    defer f.close();
+    f.seekFromEnd(0) catch {};
+    f.writeAll(line.items) catch {};
+}
+
+fn appendEscaped(out: *std.ArrayList(u8), allocator: Allocator, s: []const u8) !void {
+    for (s) |c| switch (c) {
+        '"' => try out.appendSlice(allocator, "\\\""),
+        '\\' => try out.appendSlice(allocator, "\\\\"),
+        '\n' => try out.appendSlice(allocator, "\\n"),
+        '\r' => try out.appendSlice(allocator, "\\r"),
+        '\t' => try out.appendSlice(allocator, "\\t"),
+        else => try out.append(allocator, c),
+    };
+}
+
+test "audit record appends a valid JSONL line" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    // create the file so realpath resolves, then record into it
+    {
+        const f = try tmp.dir.createFile("audit.log", .{});
+        f.close();
+    }
+    const path = try tmp.dir.realpath("audit.log", &path_buf);
+
+    record(allocator, path, "SELECT * FROM 'a.csv' WHERE x = \"q\"", 3, 42);
+    record(allocator, path, "SELECT COUNT(*) FROM 'b.csv'", null, null);
+
+    const data = try tmp.dir.readFileAlloc(allocator, "audit.log", 64 * 1024);
+    defer allocator.free(data);
+    try std.testing.expect(std.mem.indexOf(u8, data, "\"rows\":3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, data, "\"bytes\":42") != null);
+    try std.testing.expect(std.mem.indexOf(u8, data, "\\\"q\\\"") != null); // escaped quote
+    // two lines
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, data, "\n"));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,6 +6,7 @@ const engine = @import("engine.zig");
 const options_mod = @import("options.zig");
 const mcp = @import("mcp.zig");
 const install = @import("install.zig");
+const audit = @import("audit.zig");
 const zigtable = @import("zigtable");
 const Allocator = std.mem.Allocator;
 
@@ -79,6 +80,7 @@ const help_text =
     \\                          Exposes csv_query, csv_schema, csv_list tools
     \\  --root <dir>[,<dir>]    Confine all file access to these directories (blocks
     \\                          traversal/symlink escape). Use for remote/on-prem servers.
+    \\  --audit <file>          Append a JSONL record per query (timestamp, SQL) for compliance
     \\  install                 Register csvql as an MCP server in Claude (Code + Desktop),
     \\                          no manual config. Add --print to dry-run.
     \\
@@ -101,9 +103,11 @@ pub fn main() !void {
     const stdout_file = stdFile(.out);
     const stderr_file = stdFile(.err);
 
-    // --root <dir>[,<dir>...] — parse from anywhere (may precede --mcp). Empty = unrestricted.
+    // --root <dir>[,<dir>...] and --audit <file> — parse from anywhere (may precede
+    // --mcp). Empty roots = unrestricted; null audit = off.
     var roots_list = std.ArrayList([]const u8){};
     defer roots_list.deinit(allocator);
+    var audit_path: ?[]const u8 = null;
     {
         var i: usize = 1;
         while (i < args.len) : (i += 1) {
@@ -113,6 +117,9 @@ pub fn main() !void {
                     var it = std.mem.splitScalar(u8, args[i], ',');
                     while (it.next()) |r| if (r.len > 0) try roots_list.append(allocator, r);
                 }
+            } else if (std.mem.eql(u8, args[i], "--audit")) {
+                i += 1;
+                if (i < args.len) audit_path = args[i];
             }
         }
     }
@@ -129,7 +136,7 @@ pub fn main() !void {
             return;
         }
         if (argHas(args, "--mcp")) {
-            try mcp.run(allocator, roots);
+            try mcp.run(allocator, roots, audit_path);
             return;
         }
         if (std.mem.eql(u8, args[1], "install")) {
@@ -152,7 +159,7 @@ pub fn main() !void {
     }
 
     // Strip --no-header / -d / --delimiter flags; collect remainder for query parsing.
-    var opts = options_mod.Options{ .roots = roots };
+    var opts = options_mod.Options{ .roots = roots, .audit_path = audit_path };
     var clean_args = try std.ArrayList([]const u8).initCapacity(allocator, args.len);
     defer clean_args.deinit(allocator);
     try clean_args.append(allocator, args[0]); // keep program name at [0]
@@ -193,6 +200,8 @@ pub fn main() !void {
             opts.delimiter = parseDelimiter(args[i]);
         } else if (std.mem.eql(u8, arg, "--root")) {
             i += 1; // value already parsed into opts.roots above; skip it here
+        } else if (std.mem.eql(u8, arg, "--audit")) {
+            i += 1; // value already parsed into opts.audit_path above; skip it here
         } else {
             try clean_args.append(allocator, arg);
         }
@@ -236,6 +245,13 @@ pub fn main() !void {
             std.debug.print("execution error: {}\n", .{err});
             std.process.exit(1);
         };
+    }
+
+    // Audit the query after it ran (best-effort). Descriptor = the query text/args.
+    if (audit_path) |ap| {
+        const desc = try std.mem.join(allocator, " ", clean_args.items[1..]);
+        defer allocator.free(desc);
+        audit.record(allocator, ap, desc, null, null);
     }
 }
 

--- a/src/mcp.zig
+++ b/src/mcp.zig
@@ -16,6 +16,7 @@ const builtin = @import("builtin");
 const parser = @import("parser.zig");
 const engine = @import("engine.zig");
 const options_mod = @import("options.zig");
+const audit = @import("audit.zig");
 const Allocator = std.mem.Allocator;
 
 // Zig 0.15: std.ArrayList is unmanaged (allocator per-call).
@@ -46,9 +47,12 @@ const TOOLS_JSON =
 // ponytail: global — the MCP server is a single sequential process, so one
 // server-wide config is correct; no per-request roots needed.
 var g_roots: []const []const u8 = &.{};
+// Optional audit-log path, set once at startup. null = off.
+var g_audit: ?[]const u8 = null;
 
-pub fn run(allocator: Allocator, roots: []const []const u8) !void {
+pub fn run(allocator: Allocator, roots: []const []const u8, audit_path: ?[]const u8) !void {
     g_roots = roots;
+    g_audit = audit_path;
     const stdin = if (builtin.os.tag == .windows)
         std.fs.File{ .handle = std.os.windows.GetStdHandle(std.os.windows.STD_INPUT_HANDLE) catch return error.NoStdin }
     else
@@ -192,6 +196,10 @@ fn toolCsvQuery(
     defer allocator.free(res.output);
 
     const trimmed = std.mem.trim(u8, res.output, "\r\n ");
+
+    // Audit the executed query (best-effort). Records even when the result is
+    // then refused below, because the query still read the data.
+    if (g_audit) |ap| audit.record(allocator, ap, sql, std.mem.count(u8, trimmed, "{"), trimmed.len);
 
     // Hard byte cap: even 100 rows of wide columns must not flood the context.
     if (trimmed.len > MAX_RESULT_BYTES) {

--- a/src/options.zig
+++ b/src/options.zig
@@ -36,6 +36,8 @@ pub const Options = struct {
     threads: usize = 0,
     /// Treat the first row as data (not a header) and auto-name columns c1..cN.
     no_input_header: bool = false,
+    /// Append a JSONL audit record per query to this file (`--audit`). null = off.
+    audit_path: ?[]const u8 = null,
     /// Allowed root directories (`--root`). Empty = unrestricted (current behavior).
     /// When set, file access is confined to these trees (see engine.ensurePathAllowed).
     roots: []const []const u8 = &.{},


### PR DESCRIPTION
Closes #62. Adds `--audit <file>`: appends a JSONL record per query (timestamp, SQL; plus rows/bytes over MCP) so on-prem operators can prove what was queried and when. Best-effort — an audit failure never fails the query. Covers CLI and the MCP server; parsed from anywhere so `--mcp --audit` works. Documented in help, README, and SECURITY.md. +1 test.