### PR TITLE
docs: GitHub Pages landing site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>csvql — the analytical CSV query engine for AI agents</title>
+<meta name="description" content="Run SQL on CSV files in place. No database, no import, no ingest. MCP-native so an LLM can query gigabyte files for a few hundred tokens. Single static Zig binary, read-only, air-gappable.">
+<style>
+  :root { --bg:#12121f; --bg2:#16213e; --fg:#e8ecf4; --muted:#8b9bb4; --accent:#f7a41d; --accent2:#ff6f3c; --card:#1a1a2e; --line:#262a44; }
+  * { box-sizing:border-box; }
+  html { scroll-behavior:smooth; }
+  body { margin:0; background:var(--bg); color:var(--fg); font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+  code,kbd,pre { font-family:"SF Mono","Fira Code",Consolas,monospace; }
+  a { color:var(--accent); text-decoration:none; }
+  a:hover { text-decoration:underline; }
+  .wrap { max-width:900px; margin:0 auto; padding:0 20px; }
+  .accent { background:linear-gradient(90deg,var(--accent),var(--accent2)); -webkit-background-clip:text; background-clip:text; color:transparent; }
+  header { text-align:center; padding:72px 20px 40px; background:radial-gradient(ellipse at top,rgba(247,164,29,0.10),transparent 60%); }
+  header img { width:min(420px,90%); }
+  h1 { font-size:clamp(28px,5vw,44px); margin:24px 0 8px; letter-spacing:-0.5px; }
+  .sub { color:var(--muted); font-size:clamp(16px,2.4vw,20px); max-width:640px; margin:0 auto 28px; }
+  .cta { display:inline-flex; gap:12px; flex-wrap:wrap; justify-content:center; }
+  .btn { display:inline-block; padding:11px 20px; border-radius:10px; font-weight:600; }
+  .btn.primary { background:linear-gradient(90deg,var(--accent),var(--accent2)); color:#1a1a2e; }
+  .btn.ghost { border:1px solid var(--line); color:var(--fg); }
+  .btn:hover { text-decoration:none; opacity:0.92; }
+  section { padding:44px 0; border-top:1px solid var(--line); }
+  h2 { font-family:"SF Mono","Fira Code",monospace; font-size:22px; letter-spacing:-0.5px; }
+  h2 .accent { font-weight:700; }
+  pre { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:16px 18px; overflow-x:auto; font-size:14px; }
+  pre .c { color:var(--muted); }
+  pre .k { color:var(--accent); }
+  table { width:100%; border-collapse:collapse; margin:8px 0; font-size:15px; }
+  th,td { text-align:left; padding:9px 12px; border-bottom:1px solid var(--line); }
+  th { color:var(--muted); font-weight:600; }
+  td strong { color:var(--accent); }
+  .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:16px; }
+  .card { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:18px; }
+  .card h3 { margin:0 0 6px; font-size:16px; }
+  .card p { margin:0; color:var(--muted); font-size:14px; }
+  .quote { color:var(--muted); font-style:italic; border-left:3px solid var(--accent); padding-left:14px; margin:18px 0; }
+  footer { text-align:center; color:var(--muted); padding:40px 20px; border-top:1px solid var(--line); font-size:14px; }
+  .scroll { overflow-x:auto; }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <img src="logo.svg" alt="csvql">
+    <h1>The analytical CSV query engine <span class="accent">for AI agents</span></h1>
+    <p class="sub">Run SQL on CSV files in place. No database, no import, no ingest. MCP-native, so an LLM can query a gigabyte file for a few hundred tokens instead of pasting it. A single static Zig binary. Your data never leaves your machine.</p>
+    <div class="cta">
+      <a class="btn primary" href="https://github.com/melihbirim/csvql">GitHub</a>
+      <a class="btn ghost" href="#install">Install</a>
+      <a class="btn ghost" href="https://github.com/melihbirim/csvql/releases">Releases</a>
+    </div>
+  </div>
+</header>
+
+<section id="tokens">
+  <div class="wrap">
+    <h2><span class="accent">Token economics.</span> Query files instead of pasting them.</h2>
+    <p>Pasting a 417&nbsp;MB CSV into an LLM costs about <strong>230 million tokens</strong>. It fits no context window. Over MCP, the agent queries the file in place and gets back only the answer.</p>
+    <div class="scroll">
+    <table>
+      <tr><th>Question an agent asks</th><th>Tokens used</th></tr>
+      <tr><td>"How many trips per cab type?"</td><td><strong>43</strong></td></tr>
+      <tr><td>"Which year was busiest?"</td><td><strong>49</strong></td></tr>
+      <tr><td>"Average fare by passenger count?"</td><td><strong>123</strong></td></tr>
+    </table>
+    </div>
+    <p>Same answers, <strong>~1,000&ndash;500,000&times; fewer tokens</strong> &mdash; flat, regardless of file size. One command wires it into Claude.</p>
+  </div>
+</section>
+
+<section id="why">
+  <div class="wrap">
+    <h2>Why <span class="accent">csvql</span></h2>
+    <p class="quote">A database is something you load your data into. csvql is a query you run on the data where it already lives.</p>
+    <div class="grid">
+      <div class="card"><h3>MCP-native</h3><p>Ships as an MCP server. Agents query CSV/JSON directly; results are capped so a careless query can't flood the context.</p></div>
+      <div class="card"><h3>Read-only</h3><p>SELECT only. No INSERT/UPDATE/DELETE/DROP exists. It cannot modify your data.</p></div>
+      <div class="card"><h3>On-prem &amp; air-gapped</h3><p>Zero network calls, no cloud, no telemetry. Run it next to the data with <code>--root</code> sandboxing and <code>--audit</code> logging.</p></div>
+      <div class="card"><h3>Zero ingest</h3><p>Queries the raw CSV in place via mmap. No import step, no 2&nbsp;GB native store to build first.</p></div>
+      <div class="card"><h3>Fast</h3><p>SIMD parsing, lock-free parallel execution, radix sort. On large files it reads raw CSV about as fast as your OS hands it the bytes.</p></div>
+      <div class="card"><h3>Single binary</h3><p>Written in Zig. No runtime, no dependencies. macOS, Linux, Windows. Also on npm, PyPI, and Homebrew.</p></div>
+    </div>
+  </div>
+</section>
+
+<section id="perf">
+  <div class="wrap">
+    <h2><span class="accent">Faster than DuckDB</span> on raw CSV</h2>
+    <p>NYC Taxi benchmark on DuckDB's own dataset, both engines querying the raw uncompressed CSV directly (no preload), best-of-5.</p>
+    <div class="scroll">
+    <table>
+      <tr><th>File</th><th>Query</th><th>csvql</th><th>DuckDB</th><th>Speedup</th></tr>
+      <tr><td>417 MB</td><td>GROUP BY</td><td><strong>0.05s</strong></td><td>0.54s</td><td><strong>~10&times;</strong></td></tr>
+      <tr><td>8 GB</td><td>GROUP BY</td><td><strong>1.31s</strong></td><td>3.55s</td><td><strong>~2.8&times;</strong></td></tr>
+    </table>
+    </div>
+    <p>Plus <strong>~6&times; less memory</strong> and <strong>zero extra storage</strong> &mdash; DuckDB's comparable speed needs a 2.1&nbsp;GB native store built over ~22&nbsp;seconds first. Reproduce with <code>bench/bench_taxi.sh</code>.</p>
+  </div>
+</section>
+
+<section id="install">
+  <div class="wrap">
+    <h2>Install</h2>
+<pre><span class="c"># Homebrew (macOS / Linux)</span>
+brew install melihbirim/csvql/csvql
+
+<span class="c"># Query a CSV</span>
+csvql <span class="k">"SELECT cab_type, COUNT(*) FROM 'trips.csv' GROUP BY cab_type"</span>
+
+<span class="c"># Wire it into Claude (Code + Desktop), no manual config</span>
+csvql install</span></pre>
+    <p>Prebuilt binaries and one-click <code>.mcpb</code> bundles for Claude Desktop on the <a href="https://github.com/melihbirim/csvql/releases">releases page</a>. Also: <code>npm i csvql-query</code>, <code>pip install csvql-query</code>.</p>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    csvql &middot; MIT &middot; <a href="https://github.com/melihbirim/csvql">GitHub</a> &middot;
+    <a href="https://github.com/melihbirim/csvql/blob/main/SECURITY.md">Security</a> &middot;
+    <a href="https://github.com/melihbirim/csvql/labels/good%20first%20issue">Good first issues</a>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 100" width="420" height="100">
+  <defs>
+    <!-- Background gradient: dark charcoal -->
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#181826"/>
+      <stop offset="100%" style="stop-color:#141d38"/>
+    </linearGradient>
+
+    <!-- Zig orange accent gradient -->
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#f7a41d"/>
+      <stop offset="100%" style="stop-color:#ff6f3c"/>
+    </linearGradient>
+
+    <!-- Text gradient: warm white -->
+    <linearGradient id="textGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#ffffff"/>
+      <stop offset="100%" style="stop-color:#dfe4ee"/>
+    </linearGradient>
+
+    <clipPath id="clip">
+      <rect width="420" height="100" rx="14"/>
+    </clipPath>
+  </defs>
+
+  <!-- Background -->
+  <rect width="420" height="100" rx="14" fill="url(#bg)"/>
+
+  <!-- Subtle grid lines (CSV feel) -->
+  <g clip-path="url(#clip)" opacity="0.04">
+    <line x1="0" y1="25" x2="420" y2="25" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="50" x2="420" y2="50" stroke="#ffffff" stroke-width="1"/>
+    <line x1="0" y1="75" x2="420" y2="75" stroke="#ffffff" stroke-width="1"/>
+    <line x1="105" y1="0" x2="105" y2="100" stroke="#ffffff" stroke-width="1"/>
+    <line x1="210" y1="0" x2="210" y2="100" stroke="#ffffff" stroke-width="1"/>
+    <line x1="315" y1="0" x2="315" y2="100" stroke="#ffffff" stroke-width="1"/>
+  </g>
+
+  <!-- Left accent rail -->
+  <rect x="0" y="0" width="4" height="100" fill="url(#accentGrad)" opacity="0.9" clip-path="url(#clip)"/>
+
+  <!-- Wordmark: csvql — csv=white, ql=orange -->
+  <text font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+        font-size="50" font-weight="700" letter-spacing="-2" x="26" y="58">
+    <tspan fill="url(#textGrad)" opacity="0.96">csv</tspan><tspan fill="url(#accentGrad)">ql</tspan>
+  </text>
+
+  <!-- Accent underline -->
+  <rect x="27" y="65" width="176" height="2.5" rx="1.25" fill="url(#accentGrad)" opacity="0.55"/>
+
+  <!-- Tagline -->
+  <text x="28" y="83" font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+        font-size="10.5" font-weight="400" fill="#8394a8" letter-spacing="1.6">SQL analytics on CSV</text>
+
+  <!-- Proof chips (right column) — identity: tokens, agent/MCP, zero-setup -->
+  <!-- 1. token economics (the moat) -->
+  <g transform="translate(286, 13)">
+    <rect width="124" height="22" rx="11" fill="url(#accentGrad)" opacity="0.13"/>
+    <rect width="124" height="22" rx="11" fill="none" stroke="url(#accentGrad)" stroke-width="1.1" opacity="0.55"/>
+    <text x="62" y="15" font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+          font-size="10" font-weight="600" fill="#f7a41d" text-anchor="middle" letter-spacing="0.2">1000× fewer tokens</text>
+  </g>
+  <!-- 2. agent-native / MCP -->
+  <g transform="translate(286, 39)">
+    <rect width="124" height="22" rx="11" fill="url(#accentGrad)" opacity="0.13"/>
+    <rect width="124" height="22" rx="11" fill="none" stroke="url(#accentGrad)" stroke-width="1.1" opacity="0.55"/>
+    <text x="62" y="15" font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+          font-size="10" font-weight="600" fill="#f7a41d" text-anchor="middle" letter-spacing="0.2">agent-native · MCP</text>
+  </g>
+  <!-- 3. zero-setup -->
+  <g transform="translate(286, 65)">
+    <rect width="124" height="22" rx="11" fill="#ffffff" opacity="0.05"/>
+    <text x="62" y="15" font-family="'SF Mono', 'Fira Code', 'Consolas', monospace"
+          font-size="10" font-weight="400" fill="#9fb0c4" text-anchor="middle" letter-spacing="0.4">Zig · 0 deps · no ingest</text>
+  </g>
+</svg>


### PR DESCRIPTION
Self-contained landing page at docs/index.html: identity, token economics (43 vs 230M), why-csvql cards, DuckDB benchmark, install. Dark theme matching the logo. Will enable Pages on main /docs after merge.