### PR TITLE
bench: csvql vs DuckDB speed + correctness comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ bench/.taxi-data/
 
 # MCP bundle build artifact
 csvql.mcpb
+bench/.compare-data/

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Reproduce: `./bench/bench_taxi.sh --resources 1` (or `--resources --sample`).
 
 Run the full suite (all sections): [`bench/bench_all.sh`](bench/bench_all.sh)
 
+Speed **and** correctness vs DuckDB across query types: [`bench/bench_compare.py`](bench/bench_compare.py) — times each query best-of-5 and diffs the output against DuckDB (numeric-tolerant).
+
 <details>
 <summary><b>How is csvql so fast?</b></summary>
 

--- a/bench/bench_compare.py
+++ b/bench/bench_compare.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+bench_compare.py — csvql vs DuckDB: speed AND output correctness across query types.
+
+Both engines query the same raw CSV directly (no preload). Each query is timed
+best-of-N and its output is compared to DuckDB's, numeric cells with tolerance so
+float formatting differences don't count as mismatches.
+
+Usage:
+    ./bench/bench_compare.py [rows]     # default 5_000_000 (~87 MB)
+
+Needs: csvql (built or on PATH), duckdb, python3. Dataset is generated once and
+cached under bench/.compare-data/ (delete to regenerate).
+"""
+import csv
+import io
+import os
+import random
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "zig-out", "bin", "csvql")
+if not os.path.exists(BIN):
+    BIN = subprocess.run(["bash", "-lc", "command -v csvql"], capture_output=True, text=True).stdout.strip() or BIN
+
+ROWS = int(sys.argv[1]) if len(sys.argv) > 1 else 5_000_000
+DATA_DIR = os.path.join(HERE, ".compare-data")
+F = os.path.join(DATA_DIR, "emp.csv")
+DK = f"read_csv_auto('{F}')"
+
+
+def generate():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    random.seed(7)
+    depts = ["eng", "sales", "ops", "hr", "mkt"]
+    cities = ["NYC", "LA", "SF", "ATX", "SEA"]
+    with open(F, "w") as fh:
+        fh.write("dept,city,age,salary\n")
+        for _ in range(ROWS):
+            fh.write(f"{random.choice(depts)},{random.choice(cities)},{random.randint(21, 65)},{random.randint(40000, 200000)}\n")
+
+
+def run(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True).stdout
+
+
+def best(cmd, n=5):
+    b = float("inf")
+    for _ in range(n):
+        t = time.perf_counter()
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        b = min(b, time.perf_counter() - t)
+    return b
+
+
+def rows_of(txt):
+    r = list(csv.reader(io.StringIO(txt.strip())))
+    return r[1:] if r else []  # drop header
+
+
+def norm(rows):
+    def cell(c):
+        try:
+            return round(float(c), 4)
+        except ValueError:
+            return c
+    return sorted(tuple(cell(c) for c in r) for r in rows)
+
+
+def same(a, b, tol=1e-6):
+    na, nb = norm(a), norm(b)
+    if len(na) != len(nb):
+        return False
+    for ra, rb in zip(na, nb):
+        if len(ra) != len(rb):
+            return False
+        for x, y in zip(ra, rb):
+            if isinstance(x, float) and isinstance(y, float):
+                if abs(x - y) > tol * max(1, abs(y)):
+                    return False
+            elif x != y:
+                return False
+    return True
+
+
+# (label, csvql_sql, duckdb_sql). ORDER BY LIMIT compares the sort key only,
+# since ties on non-key columns are an undefined (but valid) ordering in both.
+QUERIES = [
+    ("COUNT(*)", f"SELECT COUNT(*) FROM '{F}'", f"SELECT COUNT(*) FROM {DK}"),
+    ("SUM + AVG GROUP BY", f"SELECT dept, SUM(salary), AVG(salary) FROM '{F}' GROUP BY dept",
+     f"SELECT dept, SUM(salary), AVG(salary) FROM {DK} GROUP BY dept"),
+    ("VARIANCE + STDDEV GROUP BY", f"SELECT dept, VARIANCE(salary), STDDEV(salary) FROM '{F}' GROUP BY dept",
+     f"SELECT dept, VAR_POP(salary), STDDEV_POP(salary) FROM {DK} GROUP BY dept"),
+    ("MIN + MAX GROUP BY", f"SELECT city, MIN(salary), MAX(salary) FROM '{F}' GROUP BY city",
+     f"SELECT city, MIN(salary), MAX(salary) FROM {DK} GROUP BY city"),
+    ("WHERE filter count", f"SELECT COUNT(*) FROM '{F}' WHERE salary > 150000",
+     f"SELECT COUNT(*) FROM {DK} WHERE salary > 150000"),
+    ("2-key GROUP BY", f"SELECT dept, city, COUNT(*) FROM '{F}' GROUP BY dept, city",
+     f"SELECT dept, city, COUNT(*) FROM {DK} GROUP BY dept, city"),
+    ("DISTINCT", f"SELECT DISTINCT city FROM '{F}'", f"SELECT DISTINCT city FROM {DK}"),
+    ("ORDER BY DESC LIMIT 10", f"SELECT salary FROM '{F}' ORDER BY salary DESC LIMIT 10",
+     f"SELECT salary FROM {DK} ORDER BY salary DESC LIMIT 10"),
+]
+
+
+def main():
+    if subprocess.run(["bash", "-lc", "command -v duckdb"], capture_output=True).returncode != 0:
+        sys.exit("duckdb not found on PATH")
+    if not os.path.exists(BIN):
+        sys.exit("csvql not found (build: zig build -Doptimize=ReleaseFast)")
+    if not os.path.exists(F):
+        print(f"generating {ROWS:,}-row dataset ...")
+        generate()
+    mb = os.path.getsize(F) / 1e6
+    print(f"\ncsvql vs DuckDB — {F} ({mb:.0f} MB, {ROWS:,} rows), both querying raw CSV\n")
+    print(f"  {'query':30} {'csvql':>8} {'duckdb':>8} {'speedup':>8}  correct")
+    print("  " + "-" * 66)
+    all_ok = True
+    for label, cq, dq in QUERIES:
+        ct, dt = best([BIN, cq]), best(["duckdb", "-csv", "-c", dq])
+        ok = same(rows_of(run([BIN, cq])), rows_of(run(["duckdb", "-csv", "-c", dq])))
+        all_ok = all_ok and ok
+        print(f"  {label:30} {ct:7.3f}s {dt:7.3f}s {dt / ct:7.2f}x  {'MATCH' if ok else 'DIFF'}")
+    print(f"\n  correctness: {'all queries match DuckDB' if all_ok else 'MISMATCH — investigate'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds bench/bench_compare.py: for a matrix of query types (COUNT, SUM/AVG, VARIANCE/STDDEV, MIN/MAX, WHERE, 2-key GROUP BY, DISTINCT, ORDER BY LIMIT) it times both engines best-of-5 on the same raw CSV and diffs csvql's output against DuckDB with numeric tolerance. Generates a cached dataset. Result: all queries match DuckDB, csvql ~2-6x faster. README links it.