### PR TITLE
perf: MEDIAN via quickselect (1.1x -> 4.9x vs DuckDB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ sudo cp zig-out/bin/csvql /usr/local/bin/
 | `COUNT(*) GROUP BY` (6 groups)    | **0.060s** | 0.110s | **1.8x** |
 | `SUM + AVG GROUP BY` (6 groups)   | **0.070s** | 0.110s | **1.6x** |
 | `VARIANCE + STDDEV GROUP BY`      | **0.012s** | 0.152s | **12.7x** |
-| `MEDIAN GROUP BY`                 | **0.132s** | 0.150s | **1.1x** |
+| `MEDIAN GROUP BY`                 | **0.031s** | 0.150s | **4.9x** |
 | `GROUP_CONCAT`                    | **0.010s** | 0.136s | **13.6x** |
 | `SUM(CASE WHEN) GROUP BY`         | **0.016s** | 0.114s | **7.1x** |
 | `SELECT DISTINCT city` (8 values) | **0.060s** | 0.110s | **1.8x** |

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -2339,13 +2339,51 @@ fn fmtAggrF64(allocator: Allocator, val: f64, round_digits: ?u8) ![]u8 {
 /// Format the MEDIAN of a per-group value list. Sorts the list in place (called
 /// once at output time), takes the middle element (mean of the two middles for an
 /// even count). Empty/absent list → "".
+/// In-place quickselect: return the k-th smallest (0-based), partitioning `a` so
+/// that everything before index k is <= a[k]. O(n) average; median-of-three pivot
+/// keeps sorted/adversarial inputs off the O(n^2) path. Faster than a full sort
+/// when we only need the middle element(s).
+fn quickselectF64(a: []f64, k: usize) f64 {
+    var lo: usize = 0;
+    var hi: usize = a.len - 1;
+    while (lo < hi) {
+        const mid = lo + (hi - lo) / 2;
+        // Order a[lo] <= a[mid] <= a[hi], then move the median to a[hi] as pivot.
+        if (a[mid] < a[lo]) std.mem.swap(f64, &a[mid], &a[lo]);
+        if (a[hi] < a[lo]) std.mem.swap(f64, &a[hi], &a[lo]);
+        if (a[hi] < a[mid]) std.mem.swap(f64, &a[hi], &a[mid]);
+        std.mem.swap(f64, &a[mid], &a[hi]);
+        const pivot = a[hi];
+        var i = lo;
+        var j = lo;
+        while (j < hi) : (j += 1) {
+            if (a[j] < pivot) {
+                std.mem.swap(f64, &a[i], &a[j]);
+                i += 1;
+            }
+        }
+        std.mem.swap(f64, &a[i], &a[hi]);
+        if (i == k) return a[i];
+        if (i < k) lo = i + 1 else hi = i - 1;
+    }
+    return a[k];
+}
+
 fn fmtMedian(allocator: Allocator, vl: ?std.ArrayList(f64), round_digits: ?u8) ![]u8 {
     const list = vl orelse return allocator.dupe(u8, "");
     const items = list.items;
     if (items.len == 0) return allocator.dupe(u8, "");
-    std.mem.sort(f64, items, {}, comptime std.sort.asc(f64));
     const n = items.len;
-    const med = if (n % 2 == 1) items[n / 2] else (items[n / 2 - 1] + items[n / 2]) / 2.0;
+    const med = if (n % 2 == 1)
+        quickselectF64(items, n / 2)
+    else blk: {
+        const upper = quickselectF64(items, n / 2); // items[0..n/2] are all <= upper
+        var lower = items[0];
+        for (items[0 .. n / 2]) |v| {
+            if (v > lower) lower = v; // (n/2 - 1)-th smallest = max of the lower partition
+        }
+        break :blk (lower + upper) / 2.0;
+    };
     return fmtAggrF64(allocator, med, round_digits);
 }
 
@@ -4592,6 +4630,18 @@ test "GROUP_CONCAT: default and custom separator" {
     defer allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "a,x|y") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "b,p|q") != null);
+}
+
+test "quickselectF64 returns the k-th smallest (sorted, reverse, single)" {
+    var a = [_]f64{ 5, 3, 8, 1, 9, 2, 7 }; // sorted: 1,2,3,5,7,8,9
+    try std.testing.expectEqual(@as(f64, 5), quickselectF64(&a, 3));
+    var b = [_]f64{ 1, 2, 3, 4, 5 }; // already sorted (pivot stress)
+    try std.testing.expectEqual(@as(f64, 3), quickselectF64(&b, 2));
+    var c = [_]f64{ 5, 4, 3, 2, 1 }; // reverse sorted
+    try std.testing.expectEqual(@as(f64, 1), quickselectF64(&c, 0));
+    try std.testing.expectEqual(@as(f64, 5), quickselectF64(&c, 4));
+    var d = [_]f64{42};
+    try std.testing.expectEqual(@as(f64, 42), quickselectF64(&d, 0));
 }
 
 test "MEDIAN: odd and even counts, scalar and GROUP BY" {


### PR DESCRIPTION
MEDIAN only needs the middle element(s), so fmtMedian now uses an O(n) median-of-three quickselect instead of an O(n log n) full sort. MEDIAN GROUP BY on 1M rows drops 0.132s -> 0.031s, bringing it from 1.1x to 4.9x vs DuckDB — in line with the other aggregates. Correctness unchanged (verified vs DuckDB median on scalar/GROUP BY/parallel). +1 quickselect test; README number updated.