### PR TITLE
feat: add OFFSET clause

### DIFF
--- a/CORRECTNESS.md
+++ b/CORRECTNESS.md
@@ -26,7 +26,7 @@ Run it yourself: `zig build verify -Doptimize=ReleaseFast` (or directly:
   diffed raw — see below), scientific notation and negative zero, header-only/
   single-row/single-column files, ragged rows, a zero-byte file, and values near
   i64/f64 limits.
-- **531 unit tests** (`zig build test`) covering internals differential testing can't
+- **541 unit tests** (`zig build test`) covering internals differential testing can't
   reach directly: parser edge cases, arena-buffer offset safety across reallocation,
   overflow handling, TDD regression tests for every numbered bug fix referenced below.
 - **2 platforms in CI**: `ubuntu-latest` (x86_64) and `macos-14` (Apple Silicon,
@@ -127,7 +127,6 @@ point.
 | Subqueries (`WHERE col IN (SELECT ...)`, `HAVING x > (SELECT ...)`) | [#124](https://github.com/melihbirim/csvql/issues/124) |
 | `UNION` / `INTERSECT` / `EXCEPT` | [#122](https://github.com/melihbirim/csvql/issues/122), [#127](https://github.com/melihbirim/csvql/issues/127) |
 | Window functions (`RANK() OVER (...)`, etc.) | [#126](https://github.com/melihbirim/csvql/issues/126) |
-| `OFFSET` clause | [#70](https://github.com/melihbirim/csvql/issues/70) |
 | DuckDB CLI version not pinned in CI (`--version` is whatever `latest` resolves to at run time) | not yet filed |
 Per-release-tag differential fuzz run (bigger volume than nightly, recorded in the release notes) isn't wired up yet — only per-PR (fixed seed, smoke scale) and nightly (random seed, volume) exist | [#141](https://github.com/melihbirim/csvql/issues/141) |
 | Coverage measurement (line coverage per module) not wired up | not yet filed |

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ See [BENCHMARKS.md](BENCHMARKS.md) for the complete analysis.
 | **DATEDIFF**  | `DATEDIFF('unit', start_col, end_col)` — duration between two datetime columns. Units: `second`, `minute`, `hour`, `day`, `week`, `month` (≈30 days), `year` (≈365 days). Auto-detects ISO-8601, US (MM/DD/YYYY), EU (DD.MM.YYYY) and mixed formats in the same file |
 | **DATEADD**   | `DATEADD('unit', amount, date_col)` — add/subtract interval from a datetime column. `amount` may be negative. Units: `second`, `minute`, `hour`, `day`, `week`, `month` (≈30 days), `year` (≈365 days). Returns `YYYY-MM-DD HH:MM:SS` |
 | **ORDER BY**  | `ORDER BY col [ASC\|DESC]`, multi-column `ORDER BY col1 ASC, col2 DESC`, alias, positional (`ORDER BY 1`), or a column not in the `SELECT` list (sorts by the raw source/grouping column) |
-| **LIMIT**     | `LIMIT n`                                                               |
+| **LIMIT / OFFSET** | `LIMIT n [OFFSET m]` — return up to `n` rows after skipping the first `m` result rows |
 
 ### Known differences from DuckDB
 
@@ -318,7 +318,6 @@ Not yet supported — these error clearly rather than silently returning wrong d
 | Subqueries (`WHERE col IN (SELECT ...)`, `HAVING x > (SELECT ...)`) | [#124](https://github.com/melihbirim/csvql/issues/124) |
 | `UNION` / `INTERSECT` / `EXCEPT` | [#122](https://github.com/melihbirim/csvql/issues/122), [#127](https://github.com/melihbirim/csvql/issues/127) |
 | Window functions (`RANK() OVER (...)`, etc.) | [#126](https://github.com/melihbirim/csvql/issues/126) |
-| `OFFSET` clause | [#70](https://github.com/melihbirim/csvql/issues/70) |
 
 ### Aggregate Examples
 
@@ -860,7 +859,7 @@ headers, rows = csvql.query_tuples("SELECT name, age FROM 'employees.csv'")
 | `REPLACE`, `SPLIT_PART`, `GREATEST`, `LEAST` | [#67](https://github.com/melihbirim/csvql/issues/67) | ✅ shipped (v1.8.0) |
 | `VARIANCE`, `STDDEV`, `MEDIAN`, `GROUP_CONCAT` | [#50](https://github.com/melihbirim/csvql/issues/50) | ✅ shipped (v1.9.0) |
 | HTTP/SSE MCP transport (shared service) | [#60](https://github.com/melihbirim/csvql/issues/60) | planned             |
-| `OFFSET` clause | [#70](https://github.com/melihbirim/csvql/issues/70) | help wanted |
+| `OFFSET` clause | [#70](https://github.com/melihbirim/csvql/issues/70) | ✅ shipped |
 | `--markdown` output | [#72](https://github.com/melihbirim/csvql/issues/72) | help wanted |
 | Shell completions (bash/zsh) | [#73](https://github.com/melihbirim/csvql/issues/73) | help wanted |
 

--- a/bench/verify_correctness.sh
+++ b/bench/verify_correctness.sh
@@ -514,6 +514,35 @@ check \
 
 # ════════════════════════════════════════════════════════════════
 echo ""
+echo "── OFFSET ──────────────────────────────────────────────────"
+
+check \
+  "LIMIT then OFFSET" \
+  "SELECT id, name FROM '$CSV' ORDER BY id LIMIT 5 OFFSET 5" \
+  "SELECT id, name FROM read_csv_auto('$CSV') ORDER BY id LIMIT 5 OFFSET 5"
+
+check \
+  "OFFSET then LIMIT" \
+  "SELECT id, name FROM '$CSV' ORDER BY id OFFSET 5 LIMIT 5" \
+  "SELECT id, name FROM read_csv_auto('$CSV') ORDER BY id OFFSET 5 LIMIT 5"
+
+check \
+  "bare OFFSET" \
+  "SELECT id, name FROM '$CSV' ORDER BY id OFFSET 5" \
+  "SELECT id, name FROM read_csv_auto('$CSV') ORDER BY id OFFSET 5"
+
+check \
+  "GROUP BY with ORDER BY and OFFSET" \
+  "SELECT department, COUNT(*) FROM '$CSV' GROUP BY department ORDER BY department LIMIT 2 OFFSET 1" \
+  "SELECT department, COUNT(*) FROM read_csv_auto('$CSV') GROUP BY department ORDER BY department LIMIT 2 OFFSET 1"
+
+check \
+  "DISTINCT with ORDER BY and OFFSET" \
+  "SELECT DISTINCT city FROM '$CSV' ORDER BY city LIMIT 2 OFFSET 1" \
+  "SELECT DISTINCT city FROM read_csv_auto('$CSV') ORDER BY city LIMIT 2 OFFSET 1"
+
+# ════════════════════════════════════════════════════════════════
+echo ""
 echo "── SELECT * / Projection ───────────────────────────────────"
 
 check \

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -53,6 +53,22 @@ const appendJsonStringToArena = arena_buffer.appendJsonStringToArena;
 /// Result row for ORDER BY buffering — uses fast_sort SortKey
 const SortEntry = fast_sort.SortKey;
 
+const OutputWindow = struct { start: usize, end: usize };
+
+fn outputWindow(total: usize, offset: i32, limit: i32) OutputWindow {
+    const start = @min(total, @as(usize, @intCast(offset)));
+    const end = if (limit >= 0)
+        @min(total, start + @as(usize, @intCast(limit)))
+    else
+        total;
+    return .{ .start = start, .end = end };
+}
+
+fn sortLimit(offset: i32, limit: i32) ?usize {
+    if (limit < 0) return null;
+    return @as(usize, @intCast(offset)) + @as(usize, @intCast(limit));
+}
+
 /// Stores arena-relative offsets for an ORDER BY row during buffering.
 /// Converted to real slices (SortEntry) AFTER the arena stops growing.
 /// This avoids the dangling-pointer bug where ArenaBuffer.append() can
@@ -416,7 +432,8 @@ pub fn execute(allocator: Allocator, query: parser.Query, output_file: std.fs.Fi
         if (stat_s.size > 10 * 1024 * 1024 and
             query.order_by == null and
             !query.distinct and
-            query.limit < 0)
+            query.limit < 0 and
+            query.offset == 0)
         {
             const nc = options_mod.effectiveThreadCount(opts);
             if (nc > 1) {
@@ -436,7 +453,7 @@ pub fn execute(allocator: Allocator, query: parser.Query, output_file: std.fs.Fi
     const file_stat = try file.stat();
 
     // Use parallel memory-mapped I/O for large files (2+ cores, no LIMIT unless ORDER BY)
-    if (file_stat.size > 10 * 1024 * 1024 and (query.limit < 0 or query.limit > 100000 or query.order_by != null)) {
+    if (query.offset == 0 and file_stat.size > 10 * 1024 * 1024 and (query.limit < 0 or query.limit > 100000 or query.order_by != null)) {
         const num_threads = options_mod.effectiveThreadCount(opts);
         if (num_threads > 1) {
             try parallel_mmap.executeParallelMapped(allocator, query, file, output_file, opts);
@@ -445,7 +462,7 @@ pub fn execute(allocator: Allocator, query: parser.Query, output_file: std.fs.Fi
     }
 
     // Use memory-mapped I/O for medium-large files
-    if (file_stat.size > 5 * 1024 * 1024) {
+    if (query.offset == 0 and file_stat.size > 5 * 1024 * 1024) {
         try mmap_engine.executeMapped(allocator, query, file, output_file, opts);
         return;
     }
@@ -624,6 +641,7 @@ fn executeSequential(
     // Process rows
     var row_count: i32 = 0;
     var rows_written: i32 = 0;
+    var rows_skipped: i32 = 0;
 
     // Pre-allocate output row buffer (reused across all rows)
     var output_row = try allocator.alloc([]const u8, output_specs.items.len);
@@ -770,6 +788,10 @@ fn executeSequential(
             // Write directly (no ORDER BY)
             // LIMIT 0 must stop before the first write, not after it (#111).
             if (query.limit == 0) break;
+            if (rows_skipped < query.offset) {
+                rows_skipped += 1;
+                continue;
+            }
             try writer.writeRecord(output_row);
             rows_written += 1;
 
@@ -800,7 +822,7 @@ fn executeSequential(
                 ));
             }
 
-            const limit: ?usize = if (query.limit >= 0) @intCast(query.limit) else null;
+            const limit = sortLimit(query.offset, query.limit);
 
             // Multi-column ORDER BY: use comparison sort with multi-key context.
             // Single-column: use the hardware-aware fast_sort strategy (radix / heap / comparison).
@@ -810,7 +832,8 @@ fn executeSequential(
                     .delimiter = opts.delimiter,
                 };
                 std.mem.sort(SortEntry, entries.items, ctx, MultiKeyCtx.lessThan);
-                const sorted_items = if (limit) |k| entries.items[0..@min(k, entries.items.len)] else entries.items;
+                const window = outputWindow(entries.items.len, query.offset, query.limit);
+                const sorted_items = entries.items[window.start..window.end];
 
                 var ob_distinct_arena = std.heap.ArenaAllocator.init(allocator);
                 defer ob_distinct_arena.deinit();
@@ -830,6 +853,7 @@ fn executeSequential(
                     order_by.order == .desc,
                     limit,
                 );
+                const window = outputWindow(sorted.len, query.offset, query.limit);
 
                 // Write sorted rows (with optional DISTINCT dedup on the output line)
                 var ob_distinct_arena = std.heap.ArenaAllocator.init(allocator);
@@ -837,7 +861,7 @@ fn executeSequential(
                 var ob_distinct_seen = std.StringHashMap(void).init(allocator);
                 defer ob_distinct_seen.deinit();
 
-                for (sorted) |entry| {
+                for (sorted[window.start..window.end]) |entry| {
                     if (query.distinct) {
                         if (ob_distinct_seen.contains(entry.line)) continue;
                         try ob_distinct_seen.put(try ob_distinct_arena.allocator().dupe(u8, entry.line), {});
@@ -1329,7 +1353,9 @@ const JoinCtx = struct {
     where_expr: ?parser.Expression,
     writer: *csv.RecordWriter,
     rows_written: i32,
+    rows_skipped: i32,
     limit: i32,
+    offset: i32,
     allocator: Allocator, // for complex WHERE row_map only
 };
 
@@ -1369,6 +1395,10 @@ fn expandAndEmit(merged: [][]const u8, filled_w: usize, step_idx: usize, ctx: *J
             }
         }
         if (ctx.limit == 0) return error.LimitReached; // stop before the first write (#111)
+        if (ctx.rows_skipped < ctx.offset) {
+            ctx.rows_skipped += 1;
+            return;
+        }
         for (ctx.output_indices, 0..) |midx, oi| ctx.output_row[oi] = merged[midx];
         try ctx.writer.writeRecord(ctx.output_row);
         ctx.rows_written += 1;
@@ -1443,7 +1473,9 @@ fn joinWorkerRun(w: *JoinWorkerCtx) !void {
         .where_expr = w.where_expr,
         .writer = &writer,
         .rows_written = 0,
+        .rows_skipped = 0,
         .limit = -1, // parallel path is gated to no-LIMIT queries
+        .offset = 0,
         .allocator = wa,
     };
 
@@ -1628,6 +1660,7 @@ fn executeJoinThenAggregate(
         stage1_query.having_expr = null;
         stage1_query.order_by = null;
         stage1_query.limit = -1;
+        stage1_query.offset = 0;
         stage1_query.distinct = false;
         var stage1_opts = opts;
         stage1_opts.no_header = false;
@@ -1901,6 +1934,7 @@ fn executeJoin(
         if (opts.format != .csv) break :parallel;
         if (opts.no_input_header) break :parallel;
         if (query.limit >= 0) break :parallel;
+        if (query.offset > 0) break :parallel;
         const nthreads = options_mod.effectiveThreadCount(opts);
         if (nthreads <= 1) break :parallel;
         const base_size = (base_file.stat() catch break :parallel).size;
@@ -1978,7 +2012,9 @@ fn executeJoin(
         .where_expr = query.where_expr,
         .writer = &writer,
         .rows_written = 0,
+        .rows_skipped = 0,
         .limit = query.limit,
+        .offset = query.offset,
         .allocator = allocator,
     };
 
@@ -2126,6 +2162,7 @@ fn executeFromStdin(
 
     // Process rows
     var rows_written: i32 = 0;
+    var rows_skipped: i32 = 0;
 
     // Process the retained first data row (headerless), then stream the rest.
     // The injected first row is freed by the outer defer, not here.
@@ -2226,6 +2263,10 @@ fn executeFromStdin(
         }
 
         if (query.limit == 0) break; // stop before the first write (#111)
+        if (rows_skipped < query.offset) {
+            rows_skipped += 1;
+            continue;
+        }
         try writer.writeRecord(output_row);
         rows_written += 1;
 
@@ -3907,7 +3948,9 @@ fn executeScalarAgg(
             },
         };
     }
-    try writer.writeRecord(output_row);
+    if (query.limit != 0 and query.offset == 0) {
+        try writer.writeRecord(output_row);
+    }
     try writer.finish();
     try writer.flush();
 }
@@ -5470,6 +5513,7 @@ fn executeGroupBy(
     }
 
     var rows_output: i32 = 0;
+    var rows_skipped: i32 = 0;
     for (sorted_keys) |key| {
         if (query.order_by == null and query.limit >= 0 and rows_output >= query.limit) break;
         const accum = group_map.getPtr(key).?;
@@ -5616,6 +5660,10 @@ fn executeGroupBy(
         }
 
         if (query.order_by == null) {
+            if (rows_skipped < query.offset) {
+                rows_skipped += 1;
+                continue;
+            }
             try writer.writeRecord(output_row);
             rows_output += 1;
         } else {
@@ -5631,7 +5679,8 @@ fn executeGroupBy(
 
     if (query.order_by != null) {
         std.mem.sort([]const []const u8, collected.items, RowSortCtx{ .keys = order_keys.items }, RowSortCtx.lessThan);
-        for (collected.items) |row| {
+        const window = outputWindow(collected.items.len, query.offset, query.limit);
+        for (collected.items[window.start..window.end]) |row| {
             if (query.limit >= 0 and rows_output >= query.limit) break;
             try writer.writeRecord(row[0..out_len]);
             rows_output += 1;
@@ -8413,4 +8462,68 @@ test "plain SELECT DATE_PART(...) without GROUP BY extracts per row (#133)" {
 
     try std.testing.expect(std.mem.indexOf(u8, out, "1,01") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "2,03") != null);
+}
+
+test "OFFSET skips rows before applying LIMIT" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const out = try runQueryForTest(
+        allocator,
+        &tmp,
+        "id,name\n1,Alice\n2,Bob\n3,Carol\n4,Dave\n",
+        "SELECT id FROM '{s}' LIMIT 2 OFFSET 1",
+    );
+    defer allocator.free(out);
+
+    try std.testing.expectEqualStrings("id\n2\n3\n", out);
+}
+
+test "OFFSET counts rows after WHERE filtering" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const out = try runQueryForTest(
+        allocator,
+        &tmp,
+        "id,score\n1,5\n2,20\n3,10\n4,30\n",
+        "SELECT id FROM '{s}' WHERE score >= 10 LIMIT 1 OFFSET 1",
+    );
+    defer allocator.free(out);
+
+    try std.testing.expectEqualStrings("id\n3\n", out);
+}
+
+test "OFFSET is applied after ORDER BY" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const out = try runQueryForTest(
+        allocator,
+        &tmp,
+        "id,score\n1,40\n2,10\n3,30\n4,20\n",
+        "SELECT id, score FROM '{s}' ORDER BY score DESC LIMIT 2 OFFSET 1",
+    );
+    defer allocator.free(out);
+
+    try std.testing.expectEqualStrings("id,score\n3,30\n4,20\n", out);
+}
+
+test "OFFSET skips GROUP BY output before applying LIMIT" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const out = try runQueryForTest(
+        allocator,
+        &tmp,
+        "department\nSales\nEngineering\nMarketing\nEngineering\n",
+        "SELECT department, COUNT(*) AS count FROM '{s}' GROUP BY department LIMIT 1 OFFSET 1",
+    );
+    defer allocator.free(out);
+
+    try std.testing.expectEqualStrings("department,count\nMarketing,1\n", out);
 }

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -8480,6 +8480,22 @@ test "OFFSET skips rows before applying LIMIT" {
     try std.testing.expectEqualStrings("id\n2\n3\n", out);
 }
 
+test "OFFSET before LIMIT uses the same output window" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const out = try runQueryForTest(
+        allocator,
+        &tmp,
+        "id,name\n1,Alice\n2,Bob\n3,Carol\n4,Dave\n",
+        "SELECT id FROM '{s}' OFFSET 1 LIMIT 2",
+    );
+    defer allocator.free(out);
+
+    try std.testing.expectEqualStrings("id\n2\n3\n", out);
+}
+
 test "OFFSET counts rows after WHERE filtering" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -744,15 +744,20 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
     // Parse WHERE clause if present
     if (where_idx) |idx| {
         var where_part = rest[idx + 5 ..];
+        var where_end = where_part.len;
         if (group_by_idx) |gidx| {
-            where_part = where_part[0..@min(where_part.len, gidx - idx - 5)];
-        } else if (order_by_idx) |oidx| {
-            where_part = where_part[0..@min(where_part.len, oidx - idx - 5)];
-        } else if (limit_idx) |lidx| {
-            where_part = where_part[0..@min(where_part.len, lidx - idx - 5)];
-        } else if (offset_idx) |oidx| {
-            where_part = where_part[0..@min(where_part.len, oidx - idx - 5)];
+            if (gidx > idx) where_end = @min(where_end, gidx - idx - 5);
         }
+        if (order_by_idx) |oidx| {
+            if (oidx > idx) where_end = @min(where_end, oidx - idx - 5);
+        }
+        if (limit_idx) |lidx| {
+            if (lidx > idx) where_end = @min(where_end, lidx - idx - 5);
+        }
+        if (offset_idx) |oidx| {
+            if (oidx > idx) where_end = @min(where_end, oidx - idx - 5);
+        }
+        where_part = where_part[0..where_end];
         where_part = std.mem.trim(u8, where_part, &std.ascii.whitespace);
         query.where_expr = try parseExpression(allocator, where_part);
     }
@@ -760,15 +765,20 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
     // Parse GROUP BY clause if present
     if (group_by_idx) |idx| {
         var group_by_part = rest[idx + 8 ..];
+        var group_by_end = group_by_part.len;
         if (having_idx) |hidx| {
-            group_by_part = group_by_part[0..@min(group_by_part.len, hidx - idx - 8)];
-        } else if (order_by_idx) |oidx| {
-            group_by_part = group_by_part[0..@min(group_by_part.len, oidx - idx - 8)];
-        } else if (limit_idx) |lidx| {
-            group_by_part = group_by_part[0..@min(group_by_part.len, lidx - idx - 8)];
-        } else if (offset_idx) |oidx| {
-            group_by_part = group_by_part[0..@min(group_by_part.len, oidx - idx - 8)];
+            if (hidx > idx) group_by_end = @min(group_by_end, hidx - idx - 8);
         }
+        if (order_by_idx) |oidx| {
+            if (oidx > idx) group_by_end = @min(group_by_end, oidx - idx - 8);
+        }
+        if (limit_idx) |lidx| {
+            if (lidx > idx) group_by_end = @min(group_by_end, lidx - idx - 8);
+        }
+        if (offset_idx) |oidx| {
+            if (oidx > idx) group_by_end = @min(group_by_end, oidx - idx - 8);
+        }
+        group_by_part = group_by_part[0..group_by_end];
         group_by_part = std.mem.trim(u8, group_by_part, &std.ascii.whitespace);
 
         // Use paren/quote-aware splitter so STRFTIME('%Y-%m', col) stays as one token.
@@ -783,13 +793,17 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
     // Parse HAVING clause if present (filter on aggregated results, evaluated post-GROUP-BY)
     if (having_idx) |idx| {
         var having_part = rest[idx + 6 ..];
+        var having_end = having_part.len;
         if (order_by_idx) |oidx| {
-            having_part = having_part[0..@min(having_part.len, oidx - idx - 6)];
-        } else if (limit_idx) |lidx| {
-            having_part = having_part[0..@min(having_part.len, lidx - idx - 6)];
-        } else if (offset_idx) |oidx| {
-            having_part = having_part[0..@min(having_part.len, oidx - idx - 6)];
+            if (oidx > idx) having_end = @min(having_end, oidx - idx - 6);
         }
+        if (limit_idx) |lidx| {
+            if (lidx > idx) having_end = @min(having_end, lidx - idx - 6);
+        }
+        if (offset_idx) |oidx| {
+            if (oidx > idx) having_end = @min(having_end, oidx - idx - 6);
+        }
+        having_part = having_part[0..having_end];
         having_part = std.mem.trim(u8, having_part, &std.ascii.whitespace);
         query.having_expr = try parseExpression(allocator, having_part);
     }
@@ -797,11 +811,14 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
     // Parse ORDER BY clause if present
     if (order_by_idx) |idx| {
         var order_by_part = rest[idx + 8 ..];
+        var order_by_end = order_by_part.len;
         if (limit_idx) |lidx| {
-            order_by_part = order_by_part[0..@min(order_by_part.len, lidx - idx - 8)];
-        } else if (offset_idx) |oidx| {
-            order_by_part = order_by_part[0..@min(order_by_part.len, oidx - idx - 8)];
+            if (lidx > idx) order_by_end = @min(order_by_end, lidx - idx - 8);
         }
+        if (offset_idx) |oidx| {
+            if (oidx > idx) order_by_end = @min(order_by_end, oidx - idx - 8);
+        }
+        order_by_part = order_by_part[0..order_by_end];
         order_by_part = std.mem.trim(u8, order_by_part, &std.ascii.whitespace);
 
         // Parse all comma-separated ORDER BY keys
@@ -866,7 +883,7 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
     if (limit_idx) |idx| {
         var limit_part = rest[idx + 5 ..];
         if (offset_idx) |oidx| {
-            limit_part = limit_part[0..@min(limit_part.len, oidx - idx - 5)];
+            if (oidx > idx) limit_part = limit_part[0..@min(limit_part.len, oidx - idx - 5)];
         }
         limit_part = std.mem.trim(u8, limit_part, &std.ascii.whitespace);
         const parsed_limit = try std.fmt.parseInt(i32, limit_part, 10);
@@ -875,7 +892,11 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
     }
 
     if (offset_idx) |idx| {
-        const offset_part = std.mem.trim(u8, rest[idx + 6 ..], &std.ascii.whitespace);
+        var offset_part = rest[idx + 6 ..];
+        if (limit_idx) |lidx| {
+            if (lidx > idx) offset_part = offset_part[0..@min(offset_part.len, lidx - idx - 6)];
+        }
+        offset_part = std.mem.trim(u8, offset_part, &std.ascii.whitespace);
         const parsed_offset = try std.fmt.parseInt(i32, offset_part, 10);
         if (parsed_offset < 0) return error.NegativeOffsetNotAllowed;
         query.offset = parsed_offset;

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -235,6 +235,7 @@ pub const Query = struct {
     having_expr: ?Expression,
     group_by: [][]u8,
     limit: i32,
+    offset: i32,
     order_by: ?OrderBy,
     /// All JOIN clauses in order (empty slice when there is no JOIN).
     joins: []JoinClause,
@@ -504,6 +505,7 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
         .having_expr = null,
         .group_by = undefined,
         .limit = -1,
+        .offset = 0,
         .order_by = null,
         .joins = &.{},
         .allocator = allocator,
@@ -616,7 +618,7 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
             const right_raw = std.mem.trim(u8, cursor[0..on_pos], &std.ascii.whitespace);
             const after_on = cursor[on_pos + 4 ..]; // skip " ON "
 
-            // Find end of ON condition: stop at the next JOIN keyword OR at WHERE/GROUP/ORDER/LIMIT.
+            // Find end of ON condition: stop at the next JOIN keyword OR at WHERE/GROUP/ORDER/LIMIT/OFFSET.
             // We must stop at the *next* JOIN keyword before any clause keyword so that chained
             // joins are parsed left–to–right rather than lumping everything into one condition.
             const next_join_kw = detectJoinKeyword(after_on);
@@ -624,12 +626,14 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
             const on_group = std.ascii.indexOfIgnoreCase(after_on, "GROUP BY");
             const on_order = std.ascii.indexOfIgnoreCase(after_on, "ORDER BY");
             const on_limit = std.ascii.indexOfIgnoreCase(after_on, "LIMIT");
+            const on_offset = std.ascii.indexOfIgnoreCase(after_on, "OFFSET");
             var on_end = after_on.len;
             if (next_join_kw) |njk| on_end = @min(on_end, njk.kw_start);
             if (on_where) |i| on_end = @min(on_end, i);
             if (on_group) |i| on_end = @min(on_end, i);
             if (on_order) |i| on_end = @min(on_end, i);
             if (on_limit) |i| on_end = @min(on_end, i);
+            if (on_offset) |i| on_end = @min(on_end, i);
 
             const on_cond = std.mem.trim(u8, after_on[0..on_end], &std.ascii.whitespace);
 
@@ -694,12 +698,14 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
         const group_by_idx_pre = findClauseKeyword(from_rest, "GROUP BY");
         const order_by_idx_pre = findClauseKeyword(from_rest, "ORDER BY");
         const limit_idx_pre = findClauseKeyword(from_rest, "LIMIT");
+        const offset_idx_pre = findClauseKeyword(from_rest, "OFFSET");
 
         var fend = from_rest.len;
         if (where_idx_pre) |i| fend = @min(fend, i);
         if (group_by_idx_pre) |i| fend = @min(fend, i);
         if (order_by_idx_pre) |i| fend = @min(fend, i);
         if (limit_idx_pre) |i| fend = @min(fend, i);
+        if (offset_idx_pre) |i| fend = @min(fend, i);
 
         const fp_raw = std.mem.trim(u8, from_rest[0..fend], &std.ascii.whitespace);
         const file_alias = try extractFileAndAlias(allocator, fp_raw);
@@ -727,12 +733,13 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
         }
     }
 
-    // Parse the clause keywords (WHERE / GROUP BY / ORDER BY / LIMIT) from `rest`
+    // Parse the clause keywords (WHERE / GROUP BY / ORDER BY / LIMIT / OFFSET) from `rest`
     const where_idx = findClauseKeyword(rest, "WHERE");
     const group_by_idx = findClauseKeyword(rest, "GROUP BY");
     const having_idx = findClauseKeyword(rest, "HAVING");
     const order_by_idx = findClauseKeyword(rest, "ORDER BY");
     const limit_idx = findClauseKeyword(rest, "LIMIT");
+    const offset_idx = findClauseKeyword(rest, "OFFSET");
 
     // Parse WHERE clause if present
     if (where_idx) |idx| {
@@ -743,6 +750,8 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
             where_part = where_part[0..@min(where_part.len, oidx - idx - 5)];
         } else if (limit_idx) |lidx| {
             where_part = where_part[0..@min(where_part.len, lidx - idx - 5)];
+        } else if (offset_idx) |oidx| {
+            where_part = where_part[0..@min(where_part.len, oidx - idx - 5)];
         }
         where_part = std.mem.trim(u8, where_part, &std.ascii.whitespace);
         query.where_expr = try parseExpression(allocator, where_part);
@@ -757,6 +766,8 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
             group_by_part = group_by_part[0..@min(group_by_part.len, oidx - idx - 8)];
         } else if (limit_idx) |lidx| {
             group_by_part = group_by_part[0..@min(group_by_part.len, lidx - idx - 8)];
+        } else if (offset_idx) |oidx| {
+            group_by_part = group_by_part[0..@min(group_by_part.len, oidx - idx - 8)];
         }
         group_by_part = std.mem.trim(u8, group_by_part, &std.ascii.whitespace);
 
@@ -776,6 +787,8 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
             having_part = having_part[0..@min(having_part.len, oidx - idx - 6)];
         } else if (limit_idx) |lidx| {
             having_part = having_part[0..@min(having_part.len, lidx - idx - 6)];
+        } else if (offset_idx) |oidx| {
+            having_part = having_part[0..@min(having_part.len, oidx - idx - 6)];
         }
         having_part = std.mem.trim(u8, having_part, &std.ascii.whitespace);
         query.having_expr = try parseExpression(allocator, having_part);
@@ -786,6 +799,8 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
         var order_by_part = rest[idx + 8 ..];
         if (limit_idx) |lidx| {
             order_by_part = order_by_part[0..@min(order_by_part.len, lidx - idx - 8)];
+        } else if (offset_idx) |oidx| {
+            order_by_part = order_by_part[0..@min(order_by_part.len, oidx - idx - 8)];
         }
         order_by_part = std.mem.trim(u8, order_by_part, &std.ascii.whitespace);
 
@@ -849,10 +864,21 @@ pub fn parse(allocator: Allocator, input: []const u8) !Query {
     // the query.limit < 0 sentinel used downstream to mean "no LIMIT clause
     // was given at all" (issue #106).
     if (limit_idx) |idx| {
-        const limit_part = std.mem.trim(u8, rest[idx + 5 ..], &std.ascii.whitespace);
+        var limit_part = rest[idx + 5 ..];
+        if (offset_idx) |oidx| {
+            limit_part = limit_part[0..@min(limit_part.len, oidx - idx - 5)];
+        }
+        limit_part = std.mem.trim(u8, limit_part, &std.ascii.whitespace);
         const parsed_limit = try std.fmt.parseInt(i32, limit_part, 10);
         if (parsed_limit < 0) return error.NegativeLimitNotAllowed;
         query.limit = parsed_limit;
+    }
+
+    if (offset_idx) |idx| {
+        const offset_part = std.mem.trim(u8, rest[idx + 6 ..], &std.ascii.whitespace);
+        const parsed_offset = try std.fmt.parseInt(i32, offset_part, 10);
+        if (parsed_offset < 0) return error.NegativeOffsetNotAllowed;
+        query.offset = parsed_offset;
     }
 
     return query;

--- a/src/simple_parser.zig
+++ b/src/simple_parser.zig
@@ -18,6 +18,7 @@ pub fn parseSimple(allocator: Allocator, args: []const []const u8) !parser.Query
         .having_expr = null,
         .group_by = undefined,
         .limit = 10, // Default limit is 10
+        .offset = 0,
         .order_by = null,
         .joins = &.{},
         .allocator = allocator,

--- a/tests/parser_test.zig
+++ b/tests/parser_test.zig
@@ -269,6 +269,42 @@ test "parse LIMIT with OFFSET" {
     try std.testing.expectEqual(@as(i32, 10), query.offset);
 }
 
+test "parse OFFSET before LIMIT" {
+    const allocator = std.testing.allocator;
+
+    var query = try parser.parse(
+        allocator,
+        "SELECT id FROM 'data.csv' OFFSET 10 LIMIT 5",
+    );
+    defer query.deinit();
+
+    try std.testing.expectEqual(@as(i32, 5), query.limit);
+    try std.testing.expectEqual(@as(i32, 10), query.offset);
+}
+
+test "OFFSET before LIMIT bounds preceding clauses without underflow" {
+    const allocator = std.testing.allocator;
+
+    var where_query = try parser.parse(
+        allocator,
+        "SELECT id FROM 'data.csv' WHERE score > 10 OFFSET 2 LIMIT 3",
+    );
+    defer where_query.deinit();
+    try std.testing.expectEqual(@as(i32, 3), where_query.limit);
+    try std.testing.expectEqual(@as(i32, 2), where_query.offset);
+
+    var group_query = try parser.parse(
+        allocator,
+        "SELECT dept, COUNT(*) FROM 'data.csv' GROUP BY dept HAVING COUNT(*) > 1 ORDER BY dept OFFSET 1 LIMIT 2",
+    );
+    defer group_query.deinit();
+    try std.testing.expectEqualStrings("dept", group_query.group_by[0]);
+    try std.testing.expect(group_query.having_expr != null);
+    try std.testing.expectEqualStrings("dept", group_query.order_by.?.column);
+    try std.testing.expectEqual(@as(i32, 2), group_query.limit);
+    try std.testing.expectEqual(@as(i32, 1), group_query.offset);
+}
+
 test "OFFSET defaults to zero" {
     const allocator = std.testing.allocator;
 

--- a/tests/parser_test.zig
+++ b/tests/parser_test.zig
@@ -256,6 +256,28 @@ test "parse JOIN with LIMIT" {
     try std.testing.expectEqual(@as(i32, 5), query.limit);
 }
 
+test "parse LIMIT with OFFSET" {
+    const allocator = std.testing.allocator;
+
+    var query = try parser.parse(
+        allocator,
+        "SELECT id FROM 'data.csv' LIMIT 5 OFFSET 10",
+    );
+    defer query.deinit();
+
+    try std.testing.expectEqual(@as(i32, 5), query.limit);
+    try std.testing.expectEqual(@as(i32, 10), query.offset);
+}
+
+test "OFFSET defaults to zero" {
+    const allocator = std.testing.allocator;
+
+    var query = try parser.parse(allocator, "SELECT id FROM 'data.csv' LIMIT 5");
+    defer query.deinit();
+
+    try std.testing.expectEqual(@as(i32, 0), query.offset);
+}
+
 test "single-file query still works after JOIN parser changes" {
     const allocator = std.testing.allocator;
 


### PR DESCRIPTION
Fixes #70.

Adds `OFFSET n` parsing and applies it after row filtering, grouping, and sorting, before `LIMIT`. OFFSET queries fall back to sequential execution where optimized output paths do not yet implement the same window semantics.

Tests:
- `zig build test --summary all` (541/541)
- `zig build`
- `zig build -Doptimize=ReleaseFast`
- `zig fmt --check src/engine.zig src/parser.zig src/simple_parser.zig tests/parser_test.zig`