### PR TITLE
Recover two commits dropped from PR #145's squash merge

### DIFF
--- a/CORRECTNESS.md
+++ b/CORRECTNESS.md
@@ -235,6 +235,8 @@ the expected shape for a hash-build-then-probe design, not a sign the fix is inc
 building and probing a larger hash set has real, non-zero cost, it's just linear now
 instead of quadratic. No cliff was found up to 1M resolved values.
 
+Reproduce: [`bench/bench_insubquery.sh`](bench/bench_insubquery.sh).
+
 ## Known gaps (open issues)
 
 Not yet supported. All of these **error clearly** rather than silently returning wrong

--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ Run the benchmark yourself: [`bench/bench_all.sh --section like`](bench/bench_al
 
 The base table is memory-mapped, split into line-aligned chunks, and probed against the right-side hash maps across all cores in parallel — output order in a join is undefined, so each worker streams its matches straight out with no merge step. Combined with cat-speed CSV reading (DuckDB spends most of a join parsing the CSV), joins that used to be roughly on par are now a clear win. Byte-for-byte verified against DuckDB in [`bench/verify_correctness.sh`](bench/verify_correctness.sh).
 
+**2M-row orders table, cloud VM (Intel Xeon, 4 cores) — different hardware from the tables above, not directly comparable across sections** — `WHERE col IN (SELECT ...)` (#124), which is really a semi-join: build a hash table from the subquery's result, probe it per outer row. Resolved-list size varied by how selective the lookup table's own filter is:
+
+| Resolved subquery result size | csvql | DuckDB | Speedup |
+| ------------------------------ | ---------- | ------ | ------- |
+| 6 (a typical lookup-table filter) | **0.034s** | 0.17s  | **~5x** |
+| 10,000                          | **0.045s** | 0.17s  | **~3.8x** |
+| 100,000                         | **0.088s** | 0.21s  | **~2.3x** |
+| 1,000,000                       | 0.358s     | 0.357s | even    |
+
+Row counts verified identical to DuckDB at every size. This was originally a ~20x *loss* at 10,000 resolved values (a linear-scan membership check, fine for a hand-typed literal list, not for a subquery-sized one) — found via differential testing, root-caused, and fixed with a hash-set semi-join. Full story, including the crossover point and why it flattens rather than staying ahead forever: [`CORRECTNESS.md#performance-vs-duckdb`](CORRECTNESS.md#performance-vs-duckdb).
+
 **NYC Taxi benchmark — 20M rows, 8 GB CSV, Apple M-series** — the canonical [Billion-Taxi-Rides](https://github.com/pdet/taxi-benchmark) queries on [DuckDB's own dataset](https://duckdb.org/2024/10/16/driving-csv-performance-benchmarking-duckdb-with-the-nyc-taxi-dataset). Both engines query the raw uncompressed CSV **directly** (no preload into a native store), cold per run, best-of-5, warm OS cache:
 
 | Query                                                       | csvql     | DuckDB | Speedup  |

--- a/README.md
+++ b/README.md
@@ -193,14 +193,16 @@ The base table is memory-mapped, split into line-aligned chunks, and probed agai
 
 **2M-row orders table, cloud VM (Intel Xeon, 4 cores) — different hardware from the tables above, not directly comparable across sections** — `WHERE col IN (SELECT ...)` (#124), which is really a semi-join: build a hash table from the subquery's result, probe it per outer row. Resolved-list size varied by how selective the lookup table's own filter is:
 
-| Resolved subquery result size | csvql | DuckDB | Speedup |
-| ------------------------------ | ---------- | ------ | ------- |
-| 6 (a typical lookup-table filter) | **0.034s** | 0.17s  | **~5x** |
-| 10,000                          | **0.045s** | 0.17s  | **~3.8x** |
-| 100,000                         | **0.088s** | 0.21s  | **~2.3x** |
-| 1,000,000                       | 0.358s     | 0.357s | even    |
+| Resolved subquery result size      | csvql      | DuckDB | Speedup   |
+| ----------------------------------- | ---------- | ------ | --------- |
+| 6 (a typical lookup-table filter)  | **0.034s** | 0.17s  | **~5x**   |
+| 10,000                             | **0.045s** | 0.17s  | **~3.8x** |
+| 100,000                            | **0.088s** | 0.21s  | **~2.3x** |
+| 1,000,000                          | 0.358s     | 0.357s | even      |
 
 Row counts verified identical to DuckDB at every size. This was originally a ~20x *loss* at 10,000 resolved values (a linear-scan membership check, fine for a hand-typed literal list, not for a subquery-sized one) — found via differential testing, root-caused, and fixed with a hash-set semi-join. Full story, including the crossover point and why it flattens rather than staying ahead forever: [`CORRECTNESS.md#performance-vs-duckdb`](CORRECTNESS.md#performance-vs-duckdb).
+
+Reproduce: [`bench/bench_insubquery.sh`](bench/bench_insubquery.sh)
 
 **NYC Taxi benchmark — 20M rows, 8 GB CSV, Apple M-series** — the canonical [Billion-Taxi-Rides](https://github.com/pdet/taxi-benchmark) queries on [DuckDB's own dataset](https://duckdb.org/2024/10/16/driving-csv-performance-benchmarking-duckdb-with-the-nyc-taxi-dataset). Both engines query the raw uncompressed CSV **directly** (no preload into a native store), cold per run, best-of-5, warm OS cache:
 

--- a/bench/bench_insubquery.sh
+++ b/bench/bench_insubquery.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# =============================================================================
+# bench_insubquery.sh — WHERE col IN (SELECT ...) semi-join: csvql vs DuckDB
+#
+# col IN (SELECT ...) (#124) is semantically a semi-join: build a hash table
+# from the subquery's result, probe it per outer row. Timed across four
+# resolved-list sizes (6 / 10,000 / 100,000 / 1,000,000) since the two
+# engines' relative speed depends heavily on how large that hash table is —
+# see CORRECTNESS.md's "Performance vs. DuckDB" for why, and the ~20x
+# regression this shape originally exposed before the hash-set fix.
+#
+# Usage:
+#   ./bench/bench_insubquery.sh
+#
+# Environment overrides:
+#   DUCKDB_BIN — path to duckdb binary (default: duckdb in PATH)
+#   ORDERS     — number of order rows to generate (default: 2000000)
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CSVQL="${SCRIPT_DIR}/zig-out/bin/csvql"
+DUCKDB="${DUCKDB_BIN:-duckdb}"
+ORDERS="${ORDERS:-2000000}"
+MAXCUST=3000000
+
+if [[ ! -x "$CSVQL" ]]; then
+  echo "csvql not found at $CSVQL — run: zig build -Doptimize=ReleaseFast"
+  exit 1
+fi
+if ! command -v "$DUCKDB" >/dev/null 2>&1; then
+  echo "duckdb not found in PATH (set DUCKDB_BIN=/path/to/duckdb)"
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+ORDERS_CSV="$TMP/orders.csv"
+
+echo "Generating $ORDERS order rows (customer_id spread over 1..$MAXCUST)..."
+awk -v n="$ORDERS" -v maxcust="$MAXCUST" 'BEGIN{
+  srand(42);
+  print "id,customer_id,amount";
+  for (i = 1; i <= n; i++) {
+    cust = int(rand() * maxcust) + 1;
+    amt = int(rand() * 100000) / 100;
+    print i "," cust "," amt;
+  }
+}' > "$ORDERS_CSV"
+
+# time_cmd <cmd...> — wall time in seconds, printed to var _t
+time_cmd() {
+  local t0 t1
+  t0=$(date +%s%N)
+  "$@" > /dev/null
+  t1=$(date +%s%N)
+  _t=$(echo "scale=3; ($t1 - $t0)/1000000000" | bc)
+}
+
+# run_scenario <label> <gold_modulus>
+# Customers table always spans the SAME 1..MAXCUST range as orders (so match
+# probability is comparable across scenarios, not an artifact of a narrower
+# id range) — only the gold_modulus changes, giving ~MAXCUST/gold_modulus
+# resolved values.
+run_scenario() {
+  local label="$1" gold_modulus="$2"
+  local cust_csv="$TMP/customers_${label}.csv"
+  awk -v n="$MAXCUST" -v m="$gold_modulus" 'BEGIN{
+    print "customer_id,tier";
+    for (i = 1; i <= n; i++) print i "," ((i % m == 0) ? "gold" : "silver");
+  }' > "$cust_csv"
+
+  local q_csvql="SELECT COUNT(*) FROM '${ORDERS_CSV}' WHERE customer_id IN (SELECT customer_id FROM '${cust_csv}' WHERE tier = 'gold')"
+  local q_duck="SELECT COUNT(*) FROM read_csv_auto('${ORDERS_CSV}') WHERE customer_id IN (SELECT customer_id FROM read_csv_auto('${cust_csv}') WHERE tier = 'gold')"
+
+  local csvql_out duck_out
+  csvql_out="$("$CSVQL" "$q_csvql" | tail -n +2)"
+  duck_out="$("$DUCKDB" -csv -noheader -c "$q_duck")"
+  if [[ "$csvql_out" != "$duck_out" ]]; then
+    echo "  MISMATCH ($label): csvql=$csvql_out duckdb=$duck_out"
+    return 1
+  fi
+
+  time_cmd "$CSVQL" "$q_csvql"; local t_csvql="$_t"
+  time_cmd "$DUCKDB" -csv -c "$q_duck"; local t_duck="$_t"
+  printf "  %-12s resolved=~%-10s csvql=%-8s duckdb=%-8s (rows matched: %s)\n" \
+    "$label" "$(( MAXCUST / gold_modulus ))" "${t_csvql}s" "${t_duck}s" "$csvql_out"
+}
+
+echo ""
+echo "Query: SELECT COUNT(*) FROM orders WHERE customer_id IN (SELECT customer_id FROM customers WHERE tier = 'gold')"
+echo ""
+run_scenario "small" 500000   # ~6 resolved values
+run_scenario "10k"   300      # ~10,000 resolved values
+run_scenario "100k"  30       # ~100,000 resolved values
+run_scenario "1m"    3        # ~1,000,000 resolved values


### PR DESCRIPTION
## Summary
PR #145 was squash-merged with only 3 of its 5 commits' content — the squash commit (`aaefa6f`) stopped at "Fix O(n) IN-list scan" and dropped the two commits pushed after that point:
- `2005b84` — the IN-subquery benchmark table added to README's Performance section
- `efdfe28` — `bench/bench_insubquery.sh` (the reproducible benchmark script) plus the `Reproduce:` links in both README.md and CORRECTNESS.md that point to it

Both commits are cherry-picked here as-is onto current `main`. Verified the resulting diff against `main` is byte-identical to what the original branch tip (`efdfe28`) intended — 112 insertions across `CORRECTNESS.md`, `README.md`, and the new `bench/bench_insubquery.sh`, nothing more, nothing less.

## Test plan
- [x] `zig build test` — 551/551 pass (no code changes, docs + a new bench script only)
- [x] `zig fmt --check` clean
- [x] `bash -n bench/bench_insubquery.sh` — script syntax valid (already executed successfully end-to-end before the original commit)
- [x] Confirmed `git diff origin/main fix/in-subquery-bench-script` matches exactly the delta that was missing (3 files, no unrelated changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3yB41HVAo9oKfh1BVHY4F)_