### PR TITLE
Python binding: CI coverage, plus Windows and Linux arm64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,15 +266,16 @@ jobs:
   # segfaults (139) in Debug. A ReleaseFast-only job would have shipped the
   # bug again — the same false green that let 2.5.0 out.
   #
-  # Windows is absent on purpose: python/csvql/_loader.py has no Windows
-  # branch (_lib_name returns libcsvql.so there), so the binding does not
-  # support Windows at all. Adding it is a feature, not a CI gap.
+  # Covers every platform the wheels are published for: linux x64/arm64,
+  # macos, windows. _loader.py resolves csvql.dll on Windows and looks in
+  # zig-out/bin as well as zig-out/lib, since Zig installs a DLL beside the
+  # executables rather than into lib/.
   python-binding:
     name: Python binding (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -293,11 +294,13 @@ jobs:
 
     # Debug first: it is the mode that actually catches the #149 class.
     - name: Build shared library (Debug) and test
+      shell: bash
       run: |
         zig build
-        python3 python/test_csvql.py
+        python python/test_csvql.py
 
     - name: Build shared library (ReleaseFast) and test
+      shell: bash
       run: |
         zig build -Doptimize=ReleaseFast
-        python3 python/test_csvql.py
+        python python/test_csvql.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,3 +251,53 @@ jobs:
           echo "FAIL: #149 regression - wrong output, or the process died before writing"
           exit 1
         }
+
+  # The Python/C shared library — built AND executed, same reasoning as the
+  # node-addon job above.
+  #
+  # src/lib.zig carried both #149 faults (a Zig GPA that does not work inside
+  # a dlopen()ed library, and the engine's multi-megabyte stack frames on a
+  # host thread too small for them) and was fixed the same way as the N-API
+  # addon. Nothing executed it before publishing to PyPI, exactly as nothing
+  # executed the addon before publishing to npm.
+  #
+  # Runs against BOTH build modes deliberately. Verified while writing this:
+  # with the #149 fix reverted, the suite still PASSES in ReleaseFast and
+  # segfaults (139) in Debug. A ReleaseFast-only job would have shipped the
+  # bug again — the same false green that let 2.5.0 out.
+  #
+  # Windows is absent on purpose: python/csvql/_loader.py has no Windows
+  # branch (_lib_name returns libcsvql.so there), so the binding does not
+  # support Windows at all. Adding it is a feature, not a CI gap.
+  python-binding:
+    name: Python binding (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Zig
+      uses: goto-bus-stop/setup-zig@v2
+      with:
+        version: 0.15.2
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    # Debug first: it is the mode that actually catches the #149 class.
+    - name: Build shared library (Debug) and test
+      run: |
+        zig build
+        python3 python/test_csvql.py
+
+    - name: Build shared library (ReleaseFast) and test
+      run: |
+        zig build -Doptimize=ReleaseFast
+        python3 python/test_csvql.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,16 +316,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             plat: manylinux_2_17_x86_64
+          - os: ubuntu-24.04-arm
+            plat: manylinux_2_17_aarch64
           - os: macos-14
             arch: x86_64
             plat: macosx_12_0_x86_64
           - os: macos-14
             arch: arm64
             plat: macosx_12_0_arm64
+          - os: windows-latest
+            plat: win_amd64
 
     steps:
       - uses: actions/checkout@v4
@@ -343,14 +348,26 @@ jobs:
       - name: Build Zig shared library
         run: zig build -Doptimize=ReleaseFast
 
+      # Zig installs the shared library into zig-out/lib on POSIX, but puts a
+      # Windows DLL in zig-out/bin (only the import library csvql.lib goes to
+      # lib/). _loader.py knows both locations; this staging step has to too.
       - name: Copy library into package
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             cp zig-out/lib/libcsvql.dylib python/csvql/libcsvql.dylib
+          elif [[ "$RUNNER_OS" == "Windows" ]]; then
+            cp zig-out/bin/csvql.dll python/csvql/csvql.dll
           else
             cp zig-out/lib/libcsvql.so python/csvql/libcsvql.so
           fi
+
+      # Never ship a wheel whose library does not load. This is the PyPI-side
+      # equivalent of the node-addon check — a built artifact proves nothing
+      # about whether it runs (see #149).
+      - name: Smoke-test the staged library
+        shell: bash
+        run: python python/test_csvql.py
 
       - name: Build wheel
         working-directory: python

--- a/build.zig
+++ b/build.zig
@@ -41,7 +41,9 @@ pub fn build(b: *std.Build) void {
 
     // Shared library — C ABI for Python ctypes and other FFI callers.
     // Build: zig build lib -Doptimize=ReleaseFast
-    // Output: zig-out/lib/libcsvql.dylib (macOS) or libcsvql.so (Linux)
+    // Output: zig-out/lib/libcsvql.{dylib,so} on macOS/Linux; on Windows the
+    // DLL goes to zig-out/bin/csvql.dll and only the import library
+    // csvql.lib lands in lib/ (python/csvql/_loader.py checks both).
     const lib = b.addLibrary(.{
         .name = "csvql",
         .linkage = .dynamic,
@@ -55,7 +57,10 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(lib);
 
     const lib_step = b.step("lib", "Build shared library (libcsvql)");
-    lib_step.dependOn(&lib.step);
+    // Depend on the *install* step, not the compile step: depending on
+    // lib.step compiled the library but never copied it into zig-out, so
+    // `zig build lib` silently produced nothing you could load.
+    lib_step.dependOn(&b.addInstallArtifact(lib, .{}).step);
 
     // Run command
     const run_cmd = b.addRunArtifact(exe);

--- a/python/csvql/_loader.py
+++ b/python/csvql/_loader.py
@@ -1,9 +1,9 @@
 """
-Locates and loads libcsvql (.dylib on macOS, .so on Linux).
+Locates and loads libcsvql (.dll on Windows, .dylib on macOS, .so elsewhere).
 
 Search order:
   1. Same directory as this file (installed wheel — lib bundled alongside .py)
-  2. zig-out/lib/ relative to the repo root (development build)
+  2. zig-out/ relative to the repo root (development build)
   3. Directories listed in CSVQL_LIB_PATH environment variable
 """
 
@@ -16,6 +16,9 @@ _lib_cache: ctypes.CDLL | None = None
 
 
 def _lib_name() -> str:
+    if sys.platform == "win32":
+        # Zig names the Windows shared library csvql.dll — no "lib" prefix.
+        return "csvql.dll"
     if sys.platform == "darwin":
         return "libcsvql.dylib"
     return "libcsvql.so"
@@ -27,11 +30,16 @@ def _candidate_dirs() -> list[Path]:
     # 1. Next to this .py file (wheel install)
     dirs.append(Path(__file__).parent)
 
-    # 2. zig-out/lib/ — walk up from this file looking for build.zig
+    # 2. zig-out/ — walk up from this file looking for build.zig.
+    #    Zig installs a .so/.dylib into zig-out/lib, but puts a Windows DLL
+    #    in zig-out/bin alongside the executables (only the import library
+    #    csvql.lib lands in lib/). Check both so a development build is
+    #    found on every platform.
     here = Path(__file__).resolve()
     for parent in here.parents:
         if (parent / "build.zig").exists():
             dirs.append(parent / "zig-out" / "lib")
+            dirs.append(parent / "zig-out" / "bin")
             break
 
     # 3. CSVQL_LIB_PATH env override

--- a/python/test_csvql.py
+++ b/python/test_csvql.py
@@ -1,0 +1,163 @@
+"""Tests for the csvql Python binding.
+
+These exist for the same reason nodejs/test_cli.js does: #149 shipped a
+binding that aborted the host process on an ordinary query, and nothing
+caught it because nothing ever *executed* the built library before it was
+published. release.yml builds the wheels; a build cannot catch a runtime
+fault. This suite is what CI runs so that class of bug fails here instead
+of on PyPI.
+
+src/lib.zig carried both #149 faults — a Zig GeneralPurposeAllocator that
+does not work inside a dlopen()ed library, and the engine's multi-megabyte
+stack frames on a host thread too small for them — and was fixed the same
+way as the N-API addon. The crash-shape test below is the regression guard
+for that.
+
+No pytest dependency: plain asserts and a __main__ runner, so CI needs
+nothing but a Python interpreter and a built libcsvql.
+"""
+
+import os
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import csvql  # noqa: E402
+
+TMP = Path(tempfile.gettempdir())
+PEOPLE = TMP / "csvql_py_test.csv"
+BLANKS = TMP / "csvql_py_blanks.csv"
+
+PEOPLE.write_text(
+    "id,name,city,salary\n"
+    "1,Alice,Austin,120000\n"
+    "2,Bob,Boston,80000\n"
+    "3,Carol,Austin,150000\n"
+)
+# Empty field in a middle column — exercises the NULL handling #147 touched.
+BLANKS.write_text("id,name\n1,Alice\n2,\n3,Carol\n")
+
+# Forward slashes: the path is embedded in a SQL string, and on Windows
+# tempfile returns backslashes.
+P = str(PEOPLE).replace("\\", "/")
+B = str(BLANKS).replace("\\", "/")
+
+passed = 0
+total = 0
+
+
+def check(label, actual, expected):
+    global passed, total
+    total += 1
+    if actual == expected:
+        print(f"✓ {label}")
+        passed += 1
+    else:
+        print(f"✗ {label}\n    expected: {expected!r}\n    actual:   {actual!r}")
+
+
+def check_raises(label, fn, exc=RuntimeError):
+    global passed, total
+    total += 1
+    try:
+        fn()
+    except exc:
+        print(f"✓ {label}")
+        passed += 1
+    except Exception as e:  # noqa: BLE001
+        print(f"✗ {label}\n    wrong exception: {type(e).__name__}: {e}")
+    else:
+        print(f"✗ {label}\n    no exception raised")
+
+
+# ── #149 regression ──────────────────────────────────────────────────────
+# This exact shape aborted the host process before the fix: correct bytes
+# produced, then a crash. If the binding regresses, the interpreter dies
+# here rather than returning a wrong answer.
+check(
+    "#149: SELECT one column WHERE a different column filters rows",
+    csvql.query(f"SELECT name FROM '{P}' WHERE salary > 100000"),
+    [{"name": "Alice"}, {"name": "Carol"}],
+)
+check(
+    "#149: same shape, zero rows match",
+    csvql.query(f"SELECT name FROM '{P}' WHERE salary > 999999"),
+    [],
+)
+check(
+    "#149: same shape via query_csv",
+    csvql.query_csv(f"SELECT name FROM '{P}' WHERE city = 'Austin'"),
+    "name\nAlice\nCarol\n",
+)
+
+# ── API surface ──────────────────────────────────────────────────────────
+check("query: all columns", len(csvql.query(f"SELECT * FROM '{P}'")), 3)
+check(
+    "query: GROUP BY + aggregate",
+    csvql.query(f"SELECT city, COUNT(*) AS n FROM '{P}' GROUP BY city ORDER BY n DESC"),
+    [{"city": "Austin", "n": 2}, {"city": "Boston", "n": 1}],
+)
+check(
+    "query_csv: returns CSV text",
+    csvql.query_csv(f"SELECT COUNT(*) AS n FROM '{P}'"),
+    "n\n3\n",
+)
+check(
+    "query_tuples: headers and rows",
+    csvql.query_tuples(f"SELECT id FROM '{P}' ORDER BY id LIMIT 2"),
+    (["id"], [("1",), ("2",)]),
+)
+check(
+    "OFFSET (#143), both clause orders agree",
+    (
+        csvql.query_csv(f"SELECT id FROM '{P}' ORDER BY id LIMIT 1 OFFSET 1"),
+        csvql.query_csv(f"SELECT id FROM '{P}' ORDER BY id OFFSET 1 LIMIT 1"),
+    ),
+    ("id\n2\n", "id\n2\n"),
+)
+
+# ── NULL handling (#147) ─────────────────────────────────────────────────
+check(
+    "#147: empty field is NULL for IS NULL",
+    csvql.query(f"SELECT id FROM '{B}' WHERE name IS NULL"),
+    [{"id": 2}],
+)
+check(
+    "#147: LENGTH propagates NULL rather than returning 0",
+    csvql.query_csv(f"SELECT id, LENGTH(name) FROM '{B}' WHERE name IS NULL"),
+    "id,LENGTH(name)\n2,\n",
+)
+
+# ── Errors raise, never crash or silently return wrong data ──────────────
+check_raises("bad SQL raises", lambda: csvql.query(f"SELEKT * FROM '{P}'"))
+check_raises(
+    "missing file raises",
+    lambda: csvql.query(f"SELECT * FROM '{TMP / 'csvql_py_nope.csv'}'".replace("\\", "/")),
+)
+check_raises("unknown column raises", lambda: csvql.query(f"SELECT nocol FROM '{P}'"))
+
+# ── Repeated calls: the #149 allocator fault only appeared once the
+# allocator needed a fresh page, so a single call was not enough to see it.
+try:
+    for i in range(200):
+        csvql.query(f"SELECT name FROM '{P}' WHERE salary > {100000 + i}")
+    total += 1
+    passed += 1
+    print("✓ 200 consecutive queries (crosses allocator page boundaries)")
+except Exception:  # noqa: BLE001
+    total += 1
+    print("✗ 200 consecutive queries — failed partway")
+    traceback.print_exc()
+
+print(f"\n{passed}/{total} Python binding tests passed")
+
+for f in (PEOPLE, BLANKS):
+    try:
+        os.unlink(f)
+    except OSError:
+        pass
+
+sys.exit(0 if passed == total else 1)

--- a/python/test_csvql.py
+++ b/python/test_csvql.py
@@ -53,10 +53,10 @@ def check(label, actual, expected):
     global passed, total
     total += 1
     if actual == expected:
-        print(f"✓ {label}")
+        print(f"PASS  {label}")
         passed += 1
     else:
-        print(f"✗ {label}\n    expected: {expected!r}\n    actual:   {actual!r}")
+        print(f"FAIL  {label}\n    expected: {expected!r}\n    actual:   {actual!r}")
 
 
 def check_raises(label, fn, exc=RuntimeError):
@@ -65,12 +65,12 @@ def check_raises(label, fn, exc=RuntimeError):
     try:
         fn()
     except exc:
-        print(f"✓ {label}")
+        print(f"PASS  {label}")
         passed += 1
     except Exception as e:  # noqa: BLE001
-        print(f"✗ {label}\n    wrong exception: {type(e).__name__}: {e}")
+        print(f"FAIL  {label}\n    wrong exception: {type(e).__name__}: {e}")
     else:
-        print(f"✗ {label}\n    no exception raised")
+        print(f"FAIL  {label}\n    no exception raised")
 
 
 # ── #149 regression ──────────────────────────────────────────────────────
@@ -146,10 +146,10 @@ try:
         csvql.query(f"SELECT name FROM '{P}' WHERE salary > {100000 + i}")
     total += 1
     passed += 1
-    print("✓ 200 consecutive queries (crosses allocator page boundaries)")
+    print("PASS  200 consecutive queries (crosses allocator page boundaries)")
 except Exception:  # noqa: BLE001
     total += 1
-    print("✗ 200 consecutive queries — failed partway")
+    print("FAIL  200 consecutive queries - failed partway")
     traceback.print_exc()
 
 print(f"\n{passed}/{total} Python binding tests passed")


### PR DESCRIPTION
Two commits. The first is CI-only. The second adds platform support and **does need a release to reach users**, which changes what I said when I opened this.

## 1. CI coverage (no release needed)

`src/lib.zig` carried both #149 faults and was fixed alongside the N-API addon, but the Python package had **no tests at all** and nothing executed the built library before publishing to PyPI. Same hole that let the npm package ship crashing.

**The part worth reading:** a ReleaseFast-only job would have been a false green. I verified rather than assumed — with the #149 fix reverted, the new suite **passes 14/14 in ReleaseFast** and **segfaults (exit 139) in Debug**. The fault does not manifest in the optimised build for these queries. So the job builds and runs **both modes, Debug first**.

`python/test_csvql.py` — 14 tests, no pytest dependency: the #149 crash shapes, the API surface, `OFFSET` (#143) in both clause orders, `#147` NULL handling, error paths, and 200 consecutive queries since #149's allocator fault only appeared once a fresh page was needed.

## 2. Windows and Linux arm64 (needs a release)

When I opened this I said Windows was a matrix oversight. **That was wrong.** `_loader.py`'s `_lib_name()` had no Windows branch — it returned `libcsvql.so` there, which will never exist. The binding could never have worked on Windows. That, not the workflow, is why PyPI shipped 3 wheels to npm's 5.

- **`_lib_name()`** now returns `csvql.dll` on `win32`
- **`_candidate_dirs()`** now checks `zig-out/bin` as well as `zig-out/lib`. Zig installs a Windows DLL beside the executables; only the import library `csvql.lib` lands in `lib/`. The wheel staging step in `release.yml` needed the same distinction.
- **`release.yml` publish-pypi matrix** → 5 wheels: `manylinux_2_17_x86_64`, `manylinux_2_17_aarch64`, `macosx_12_0_x86_64`, `macosx_12_0_arm64`, `win_amd64`. `fail-fast: false`.
- **`release.yml` now smoke-tests the staged library before publishing.** A built wheel proves nothing about whether it loads — that is exactly what #149 cost.
- **CI `python-binding` job** covers the same four runners: ubuntu x64, ubuntu arm64, macos-14, windows.

### Also fixed

`zig build lib` depended on the *compile* step rather than the *install* step, so it compiled the library and never copied it into `zig-out` — the command silently produced nothing you could load. Found while checking what each target emits.

## Verification

- [x] `python/test_csvql.py` — 14/14 on Debug **and** ReleaseFast
- [x] Regression check: fix reverted → ReleaseFast passes, Debug segfaults (139). This is what motivated the two-mode design.
- [x] Cross-built all five published targets: `x86_64-linux`, `aarch64-linux`, `x86_64-macos`, `aarch64-macos`, `x86_64-windows` — all produce a loadable artifact
- [x] Windows DLL verified to export `csvql_query_csv`, `csvql_query_json`, `csvql_free`
- [x] Simulated the wheel staging: `_lib_name()` on `win32` returns `csvql.dll`, matching the filename the staging step writes
- [x] `zig build test` 567/567, `zig fmt --check` clean
- [x] `zig build lib` now actually installs

Executed on Linux x64. Windows and macOS behaviour is what the CI job exists to establish — I can cross-*build* them here but not run them.

## On the release

Nothing is broken on PyPI today: the #149 fix is already in the live 2.6.0 wheels. This adds platforms that were previously impossible and guards against regression. It can ride whenever you next release naturally — there's no urgency, and merging it costs nothing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3yB41HVAo9oKfh1BVHY4F