### PR TITLE
Eliminate implicit disk writes (memfd on Linux), document security guarantees

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,13 @@ csvql is built to be safe to run next to sensitive data, including on corporate 
 
 **No data egress.** Data stays on the machine. A query returns only its result, never the file. Over MCP, `csv_query` results are capped (about 12 KB per response), which also limits how much an agent can pull out across queries.
 
-**No network, air gappable.** csvql makes zero outbound connections. No telemetry, no cloud, no API keys, no update checks. It runs fully offline.
+**No network, air gappable.** csvql makes zero outbound connections. No telemetry, no cloud, no API keys, no update checks. It runs fully offline. Verified by reading the source, not just asserted: there is no `std.net`, `std.http`, or socket call anywhere in the codebase.
+
+**No unrequested disk writes.** csvql writes to disk only when you tell it to: `-o/--output <file>` and `--audit <file>` are the only two ways to make it write something, and both require an explicit flag.
+
+A few internal operations (resolving `IN (SELECT ...)` subqueries, staging a JOIN followed by GROUP BY, and `--table` output rendering) need a scratch buffer while a query runs. **On Linux**, that scratch buffer is `memfd_create()` — an anonymous, RAM-backed file descriptor that was never given a path and is never written to a real disk block. **On macOS and Windows**, those same four internal operations still fall back to a real, immediately-deleted temp file in `$TMPDIR`/`%TEMP%` — a known, tracked gap, not a silent one. See [#164](https://github.com/melihbirim/csvql/issues/164) for the work closing it (macOS's POSIX shared-memory alternative to `memfd_create` turns out not to support the streaming-write pattern csvql needs; closing this fully needs a small internal refactor, not a workaround).
+
+If you're evaluating csvql for an air-gapped or hardened-filesystem environment, verify this claim yourself rather than take it on faith — `strace -f -e trace=network,open,openat` (Linux) or the equivalent will show it directly. That's the point: this is meant to be provable, not just stated.
 
 **Filesystem scoping.** By default csvql can read any file the process user can. Pass `--root <dir>[,<dir>]` to confine all file access (CLI and MCP) to those directory trees. Paths are resolved with `realpath`, so `../` traversal and symlink escape are rejected. Always set `--root` when exposing csvql to an agent or another user.
 

--- a/bench/parser_bench.zig
+++ b/bench/parser_bench.zig
@@ -1,0 +1,80 @@
+/// WHERE-expression parser benchmark: times parser.parse() over a fixed
+/// corpus of representative full queries (simple comparisons, AND/OR
+/// chains, BETWEEN, LIKE/ILIKE, IN literal + subquery, scalar functions,
+/// modulo, NOT, nested parens). Baseline for the tokenizer/recursive-descent
+/// rewrite of the WHERE expression grammar — run before and after to catch
+/// a perf regression, not just a correctness one.
+///
+/// Usage:
+///   zig build bench-parser
+const std = @import("std");
+const parser = @import("parser");
+
+const WARM_UP_ITERS: usize = 3;
+const TIMED_ITERS: usize = 12;
+
+const QUERIES = [_][]const u8{
+    "SELECT id FROM 'f.csv' WHERE id = 5",
+    "SELECT id FROM 'f.csv' WHERE age > 30 AND city = 'Austin'",
+    "SELECT id FROM 'f.csv' WHERE age > 30 OR city = 'Austin'",
+    "SELECT id FROM 'f.csv' WHERE age BETWEEN 20 AND 40",
+    "SELECT id FROM 'f.csv' WHERE age BETWEEN 20 AND 40 OR city = 'Austin'",
+    "SELECT id FROM 'f.csv' WHERE age BETWEEN 20 AND 40 AND city = 'Austin' AND salary > 50000",
+    "SELECT id FROM 'f.csv' WHERE name LIKE 'A%'",
+    "SELECT id FROM 'f.csv' WHERE name ILIKE '%smith%'",
+    "SELECT id FROM 'f.csv' WHERE department IN ('Sales', 'Engineering', 'HR')",
+    "SELECT id FROM 'f.csv' WHERE department NOT IN ('Sales', 'Engineering')",
+    "SELECT id FROM 'f.csv' WHERE id IN (SELECT id FROM 'g.csv' WHERE department LIKE 'Op%')",
+    "SELECT id FROM 'f.csv' WHERE id NOT IN (SELECT id FROM 'g.csv' WHERE age BETWEEN 20 AND 30)",
+    "SELECT id FROM 'f.csv' WHERE NOT (age > 30)",
+    "SELECT id FROM 'f.csv' WHERE id % 2 = 0",
+    "SELECT id FROM 'f.csv' WHERE DATEDIFF('day', start_col, end_col) > 5",
+    "SELECT id FROM 'f.csv' WHERE age IS NULL OR city IS NOT NULL",
+    "SELECT id FROM 'f.csv' WHERE (age > 20 AND age < 40) OR (city = 'Austin' AND department = 'Sales')",
+    "SELECT id FROM 'f.csv' WHERE age > 20 AND age < 40 AND city != 'Austin' AND department = 'Sales' OR salary > 90000",
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    std.debug.print(
+        \\
+        \\=================================================================
+        \\ WHERE-expression parser benchmark
+        \\=================================================================
+        \\ Corpus : {d} queries, {d} warm-up + {d} timed passes
+        \\=================================================================
+        \\
+    , .{ QUERIES.len, WARM_UP_ITERS, TIMED_ITERS });
+
+    for (0..WARM_UP_ITERS) |_| try runPass(allocator);
+
+    var times = std.ArrayListUnmanaged(f64){};
+    defer times.deinit(allocator);
+    for (0..TIMED_ITERS) |_| {
+        const t0 = std.time.nanoTimestamp();
+        try runPass(allocator);
+        const t1 = std.time.nanoTimestamp();
+        try times.append(allocator, @as(f64, @floatFromInt(t1 - t0)) / 1_000_000.0);
+    }
+
+    std.mem.sort(f64, times.items, {}, std.sort.asc(f64));
+    const median = times.items[times.items.len / 2];
+    var sum: f64 = 0;
+    for (times.items) |t| sum += t;
+    const mean = sum / @as(f64, @floatFromInt(times.items.len));
+
+    std.debug.print("median: {d:.4} ms/pass ({d:.2} us/query)\n", .{ median, (median * 1000.0) / @as(f64, @floatFromInt(QUERIES.len)) });
+    std.debug.print("mean:   {d:.4} ms/pass\n", .{mean});
+    std.debug.print("min:    {d:.4} ms/pass\n", .{times.items[0]});
+    std.debug.print("max:    {d:.4} ms/pass\n", .{times.items[times.items.len - 1]});
+}
+
+fn runPass(allocator: std.mem.Allocator) !void {
+    for (QUERIES) |q| {
+        var query = try parser.parse(allocator, q);
+        query.deinit();
+    }
+}

--- a/build.zig
+++ b/build.zig
@@ -135,6 +135,28 @@ pub fn build(b: *std.Build) void {
     const groupby_bench_step = b.step("bench-groupby", "Run GROUP BY benchmark");
     groupby_bench_step.dependOn(&groupby_bench_run.step);
 
+    // WHERE-expression parser benchmark
+    const parser_bench_mod = b.addModule("parser", .{
+        .root_source_file = b.path("src/parser.zig"),
+    });
+    const parser_bench_root = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+        .root_source_file = b.path("bench/parser_bench.zig"),
+    });
+    parser_bench_root.addImport("parser", parser_bench_mod);
+    const parser_bench_exe = b.addExecutable(.{
+        .name = "parser_bench",
+        .root_module = parser_bench_root,
+    });
+    parser_bench_exe.linkLibC();
+    b.installArtifact(parser_bench_exe);
+
+    const parser_bench_run = b.addRunArtifact(parser_bench_exe);
+    parser_bench_run.step.dependOn(b.getInstallStep());
+    const parser_bench_step = b.step("bench-parser", "Run WHERE-expression parser benchmark");
+    parser_bench_step.dependOn(&parser_bench_run.step);
+
     // Example executables for library users
     const csv_example = b.addExecutable(.{
         .name = "csv_reader_example",
@@ -248,6 +270,20 @@ pub fn build(b: *std.Build) void {
     parser_tests.root_module.addImport("parser", parser_module);
     const run_parser_tests = b.addRunArtifact(parser_tests);
     test_step.dependOn(&run_parser_tests.step);
+
+    // WHERE-expression precedence/grammar tests (#154, #155 regressions +
+    // tokenizer/recursive-descent rewrite acceptance criteria)
+    const where_expr_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .root_source_file = b.path("tests/where_expr_precedence_test.zig"),
+        }),
+    });
+    where_expr_tests.linkLibC();
+    where_expr_tests.root_module.addImport("parser", parser_module);
+    const run_where_expr_tests = b.addRunArtifact(where_expr_tests);
+    test_step.dependOn(&run_where_expr_tests.step);
 
     // CSV tests
     const csv_tests = b.addTest(.{

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -11,6 +11,7 @@ const options_mod = @import("options.zig");
 const scalar = @import("scalar.zig");
 const datetime = @import("datetime.zig");
 const arena_buffer = @import("arena_buffer.zig");
+const memfile = @import("memfile.zig");
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
 
@@ -391,16 +392,8 @@ fn runSubqueryForInList(allocator: Allocator, sql: []const u8, opts: options_mod
     // rather than a copy (see resolveInSubqueries).
     try resolveQuery(allocator, &subquery, opts);
 
-    const tmp_dir: []const u8 = (if (builtin.os.tag == .windows)
-        std.process.getEnvVarOwned(sa, "TEMP")
-    else
-        std.process.getEnvVarOwned(sa, "TMPDIR")) catch (if (builtin.os.tag == .windows) "." else "/tmp");
-    const stamp = std.time.nanoTimestamp();
-    const tmp_path = try std.fmt.allocPrint(sa, "{s}{c}csvql_insubq_{d}.tmp", .{ tmp_dir, std.fs.path.sep, stamp });
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
-
     const captured = blk: {
-        const tmp_file = try std.fs.cwd().createFile(tmp_path, .{ .truncate = true, .read = true });
+        const tmp_file = try memfile.createMemoryBackedFile(sa, "insubq");
         defer tmp_file.close();
         var sub_opts = opts;
         sub_opts.no_header = false; // always emit a header so the skip below is reliable
@@ -1568,7 +1561,7 @@ const JoinWorkerCtx = struct {
     output_indices: []const usize,
     where_merged_idx: ?usize,
     where_expr: ?parser.Expression,
-    tmp_path: []const u8,
+    file: std.fs.File,
     opts: options_mod.Options,
     parent_allocator: Allocator,
     err: ?anyerror = null,
@@ -1581,8 +1574,10 @@ fn joinWorker(w: *JoinWorkerCtx) void {
 }
 
 fn joinWorkerRun(w: *JoinWorkerCtx) !void {
-    const out = try std.fs.cwd().createFile(w.tmp_path, .{ .truncate = true });
-    defer out.close();
+    // Owned and closed by the main thread after it reads this worker's rows
+    // back (seekTo(0) + read on this same handle) — not here, and not by
+    // path, since w.file may be an anonymous memfd with no real path.
+    const out = w.file;
     var writer = csv.RecordWriter.init(out, w.opts);
     defer writer.deinit();
 
@@ -1775,17 +1770,17 @@ fn executeJoinThenAggregate(
     }
 
     // ── Stage 1: materialize the joined+filtered rows (SELECT *, no LIMIT) ──
-    const tmp_dir: []const u8 = (if (builtin.os.tag == .windows)
-        std.process.getEnvVarOwned(aa, "TEMP")
-    else
-        std.process.getEnvVarOwned(aa, "TMPDIR")) catch (if (builtin.os.tag == .windows) "." else "/tmp");
-    const stamp = std.time.nanoTimestamp();
-    const tmp_path = try std.fmt.allocPrint(aa, "{s}{c}csvql_joinagg_{d}.tmp", .{ tmp_dir, std.fs.path.sep, stamp });
-    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+    const staged = try memfile.createMemoryBackedFileWithPath(aa, "joinagg");
+    defer staged.cleanup(aa);
+    // Kept open through stage 2, not just stage 1: on Linux, staged.path is
+    // /proc/self/fd/N, which only resolves while fd N is still open in this
+    // process — closing it right after stage 1 would make stage 2's reopen
+    // of that path fail with ENOENT.
+    defer staged.file.close();
+    const tmp_path = staged.path;
 
     {
-        const tmp_file = try std.fs.cwd().createFile(tmp_path, .{ .truncate = true });
-        defer tmp_file.close();
+        const tmp_file = staged.file;
         var stage1_query = query;
         stage1_query.all_columns = true;
         stage1_query.columns = &[_][]u8{};
@@ -2078,16 +2073,10 @@ fn executeJoin(
         const header_nl = std.mem.indexOfScalar(u8, base_data, '\n') orelse break :parallel;
         const chunks = try splitLineChunks(base_data, header_nl + 1, nthreads, aa, opts.delimiter);
 
-        const tmp_dir: []const u8 = (if (builtin.os.tag == .windows)
-            std.process.getEnvVarOwned(aa, "TEMP")
-        else
-            std.process.getEnvVarOwned(aa, "TMPDIR")) catch (if (builtin.os.tag == .windows) "." else "/tmp");
-        const stamp = std.time.nanoTimestamp();
-
         const workers = try aa.alloc(JoinWorkerCtx, nthreads);
         const threads = try aa.alloc(std.Thread, nthreads);
         for (0..nthreads) |i| {
-            const tmp_path = try std.fmt.allocPrint(aa, "{s}{c}csvql_join_{d}_{d}.tmp", .{ tmp_dir, std.fs.path.sep, stamp, i });
+            const wfile = try memfile.createMemoryBackedFile(aa, "join");
             workers[i] = .{
                 .data = base_data,
                 .chunk_start = chunks[i][0],
@@ -2103,7 +2092,7 @@ fn executeJoin(
                 .output_indices = output_indices.items,
                 .where_merged_idx = where_merged_idx,
                 .where_expr = query.where_expr,
-                .tmp_path = tmp_path,
+                .file = wfile,
                 .opts = opts,
                 .parent_allocator = allocator,
             };
@@ -2116,11 +2105,9 @@ fn executeJoin(
         try writer.flush();
         var copy_buf: [64 * 1024]u8 = undefined;
         for (workers) |wk| {
-            const tf = try std.fs.cwd().openFile(wk.tmp_path, .{});
-            defer {
-                tf.close();
-                std.fs.cwd().deleteFile(wk.tmp_path) catch {};
-            }
+            const tf = wk.file;
+            defer tf.close();
+            try tf.seekTo(0);
             while (true) {
                 const n = try tf.read(&copy_buf);
                 if (n == 0) break;

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,6 +7,7 @@ const options_mod = @import("options.zig");
 const mcp = @import("mcp.zig");
 const install = @import("install.zig");
 const audit = @import("audit.zig");
+const memfile = @import("memfile.zig");
 const zigtable = @import("zigtable");
 const Allocator = std.mem.Allocator;
 
@@ -331,22 +332,14 @@ pub fn main() !void {
     }
 }
 
-/// Run the engine into a temp file, read back, parse CSV, render via zigtable.
+/// Run the engine into a memory-backed scratch file, read back, parse CSV,
+/// render via zigtable.
 fn renderTableOutput(allocator: Allocator, query: parser.Query, stdout_file: std.fs.File, opts: options_mod.Options) !void {
-    // Write CSV to a temp file
-    var tmp_buf: [128]u8 = undefined;
-    const tmp_path = try std.fmt.bufPrint(&tmp_buf, "/tmp/csvql_{d}.tmp", .{std.time.milliTimestamp()});
-    {
-        const tmp_file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
-        defer tmp_file.close();
-        try engine.execute(allocator, query, tmp_file, opts);
-    }
-    defer std.fs.deleteFileAbsolute(tmp_path) catch {};
-
-    // Read back
-    const tmp_read = try std.fs.openFileAbsolute(tmp_path, .{});
-    defer tmp_read.close();
-    const csv_data = try tmp_read.readToEndAlloc(allocator, 4 * 1024 * 1024 * 1024);
+    const tmp_file = try memfile.createMemoryBackedFile(allocator, "table");
+    defer tmp_file.close();
+    try engine.execute(allocator, query, tmp_file, opts);
+    try tmp_file.seekTo(0);
+    const csv_data = try tmp_file.readToEndAlloc(allocator, 4 * 1024 * 1024 * 1024);
     defer allocator.free(csv_data);
 
     // Use a quote-aware record iterator so multiline quoted fields are not split prematurely.

--- a/src/memfile.zig
+++ b/src/memfile.zig
@@ -1,0 +1,115 @@
+//! Anonymous, memory-backed file descriptors — used everywhere the engine
+//! needs a std.fs.File-shaped scratch buffer (subquery resolution, join
+//! staging, --table rendering) but must never touch a real disk block, per
+//! the on-prem/air-gapped promise: those internal staging steps are an
+//! implementation detail, not something the caller asked for, and used to
+//! silently write to $TMPDIR/csvql_*.tmp before this existed.
+//!
+//! Linux/FreeBSD: memfd_create() — an anonymous file that lives entirely in
+//! page cache/RAM, was never given a path, and disappears with the last
+//! close().
+//!
+//! macOS and Windows are known, documented exceptions, not silent gaps:
+//! macOS has no memfd_create, and its POSIX shm_open() alternative turns out
+//! not to work for what this actually needs — verified by hand, a freshly
+//! shm_open'd fd rejects plain read()/write() with ENXIO; Darwin's shared
+//! memory objects are mmap-only, not stream-writable. The engine's output
+//! path (engine.execute takes a concrete std.fs.File and calls writeAll
+//! repeatedly as rows are produced, an unknown-length stream, not a
+//! fixed-size buffer sized once upfront) doesn't fit that shape without a
+//! larger rewrite of engine.execute's signature to accept a generic writer
+//! instead of std.fs.File. Windows has no equivalent primitive exposed by
+//! Zig's std at all today. Both fall back to the same real-temp-file
+//! behavior this file replaced on Linux — not a regression, just not yet
+//! improved there. See CORRECTNESS.md / the on-prem security doc for the
+//! current platform-by-platform status of this guarantee.
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+pub fn createMemoryBackedFile(allocator: Allocator, name_hint: []const u8) !std.fs.File {
+    switch (builtin.os.tag) {
+        .linux, .freebsd => {
+            const fd = try std.posix.memfd_create(name_hint, 0);
+            return std.fs.File{ .handle = fd };
+        },
+        else => {
+            // No memory-backed primitive available here — fall back to a
+            // real (self-deleting) temp file, same behavior this replaced.
+            const env_var = if (builtin.os.tag == .windows) "TEMP" else "TMPDIR";
+            const tmp_dir_owned = std.process.getEnvVarOwned(allocator, env_var) catch null;
+            defer if (tmp_dir_owned) |t| allocator.free(t);
+            const tmp_dir: []const u8 = tmp_dir_owned orelse (if (builtin.os.tag == .windows) "." else "/tmp");
+            const stamp = std.time.nanoTimestamp();
+            const tmp_path = try std.fmt.allocPrint(allocator, "{s}{c}csvql_{s}_{d}.tmp", .{ tmp_dir, std.fs.path.sep, name_hint, stamp });
+            defer allocator.free(tmp_path);
+            const f = try std.fs.cwd().createFile(tmp_path, .{ .truncate = true, .read = true });
+            std.fs.cwd().deleteFile(tmp_path) catch {}; // unlink now; fd stays valid until close()
+            return f;
+        },
+    }
+}
+
+/// Same idea, but for the one call site that needs a real re-openable path
+/// afterward (join+aggregate staging: stage 2 reopens the staged result via
+/// query.file_path, not through the handle stage 1 wrote with). A bare
+/// memfd has no path — Linux's procfs gives it one anyway via
+/// /proc/self/fd/N, which still resolves to the same anonymous, RAM-backed
+/// file, not a real disk entry. Other platforms fall back to a real temp
+/// file that stays on disk (with a real path) until the caller calls
+/// cleanup() — same behavior this replaced there, not yet improved.
+pub const FileWithPath = struct {
+    file: std.fs.File,
+    path: []const u8,
+    owns_path: bool,
+    is_real_file: bool,
+
+    pub fn cleanup(self: FileWithPath, allocator: Allocator) void {
+        if (self.is_real_file) std.fs.cwd().deleteFile(self.path) catch {};
+        if (self.owns_path) allocator.free(self.path);
+    }
+};
+
+pub fn createMemoryBackedFileWithPath(allocator: Allocator, name_hint: []const u8) !FileWithPath {
+    switch (builtin.os.tag) {
+        .linux => {
+            const fd = try std.posix.memfd_create(name_hint, 0);
+            const path = try std.fmt.allocPrint(allocator, "/proc/self/fd/{d}", .{fd});
+            return .{ .file = std.fs.File{ .handle = fd }, .path = path, .owns_path = true, .is_real_file = false };
+        },
+        else => {
+            const env_var = if (builtin.os.tag == .windows) "TEMP" else "TMPDIR";
+            const tmp_dir_owned = std.process.getEnvVarOwned(allocator, env_var) catch null;
+            defer if (tmp_dir_owned) |t| allocator.free(t);
+            const tmp_dir: []const u8 = tmp_dir_owned orelse (if (builtin.os.tag == .windows) "." else "/tmp");
+            const stamp = std.time.nanoTimestamp();
+            const path = try std.fmt.allocPrint(allocator, "{s}{c}csvql_{s}_{d}.tmp", .{ tmp_dir, std.fs.path.sep, name_hint, stamp });
+            const f = try std.fs.cwd().createFile(path, .{ .truncate = true, .read = true });
+            return .{ .file = f, .path = path, .owns_path = true, .is_real_file = true };
+        },
+    }
+}
+
+test "createMemoryBackedFile writes and reads back in RAM" {
+    var f = try createMemoryBackedFile(std.testing.allocator, "test");
+    defer f.close();
+    try f.writeAll("hello world\n");
+    try f.seekTo(0);
+    var buf: [64]u8 = undefined;
+    const n = try f.readAll(&buf);
+    try std.testing.expectEqualStrings("hello world\n", buf[0..n]);
+}
+
+test "createMemoryBackedFileWithPath is reopenable by its own path" {
+    const allocator = std.testing.allocator;
+    const fwp = try createMemoryBackedFileWithPath(allocator, "test");
+    defer fwp.cleanup(allocator);
+    try fwp.file.writeAll("row1\nrow2\n");
+    try fwp.file.sync();
+
+    var reopened = try std.fs.cwd().openFile(fwp.path, .{});
+    defer reopened.close();
+    var buf: [64]u8 = undefined;
+    const n = try reopened.readAll(&buf);
+    try std.testing.expectEqualStrings("row1\nrow2\n", buf[0..n]);
+}

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -1014,16 +1014,47 @@ fn findClauseKeyword(s: []const u8, keyword: []const u8) ?usize {
     return null;
 }
 
-/// Case-insensitive substring search for `needle`, skipping over
-/// single-quoted strings and anything inside parentheses (depth > 0) — so a
-/// `col IN (SELECT ... WHERE other_col LIKE '...')` subquery's own LIKE/IS
-/// NULL/IN keywords are never mistaken for the outer predicate's operator
-/// (#155). Returns the index of the start of `needle` in `s`, or null.
-fn findTopLevelSubstr(s: []const u8, needle: []const u8) ?usize {
-    if (needle.len == 0 or s.len < needle.len) return null;
+const LeafOpKind = enum { is_not_null, is_null, ilike, like, not_in, in_kw, percent, ge, le, ne, eq, gt, lt, none };
+
+/// Single left-to-right, quote/paren-depth-aware scan of an already-isolated
+/// leaf predicate (parseExpression's OR/AND/BETWEEN splitting above
+/// guarantees no top-level AND/OR/BETWEEN remains by the time this runs) for
+/// the first leaf-level operator/keyword. Replaces what used to be up to
+/// eight independent full-string re-scans — one per candidate operator, in a
+/// fixed and easy-to-get-wrong priority order that depended on which `if`
+/// happened to run first in source order (that's exactly how #154 and #155
+/// slipped through) — with one pass whose priority is data (the order of
+/// `candidates` below), not code position: adding operator #9 means adding
+/// a table row, not finding the right place in a growing if-cascade.
+///
+/// NOT IN is checked before IN, and IS NOT NULL before IS NULL, for the same
+/// reason the old cascade needed that order: the shorter pattern's text is a
+/// substring of the longer one's, so checking short-before-long here would
+/// match the wrong one first (#115).
+///
+/// IN / NOT IN carry a guard: the text before the match must not itself
+/// contain an operator/quote/paren character, otherwise this "IN (" isn't
+/// really the outer predicate's IN — it's part of something else on the
+/// left-hand side. On a guard failure the scan does not stop; it keeps
+/// going past that position, mirroring the old cascade's behavior of simply
+/// falling through to the next check when a candidate didn't pan out.
+fn scanLeafOperator(s: []const u8) struct { op: LeafOpKind, idx: usize } {
+    const Candidate = struct { pat: []const u8, op: LeafOpKind };
+    const candidates = [_]Candidate{
+        .{ .pat = " IS NOT NULL", .op = .is_not_null },
+        .{ .pat = " IS NULL", .op = .is_null },
+        .{ .pat = " NOT IN (", .op = .not_in },
+        .{ .pat = " ILIKE ", .op = .ilike },
+        .{ .pat = " LIKE ", .op = .like },
+        .{ .pat = " IN (", .op = .in_kw },
+        .{ .pat = " % ", .op = .percent },
+        .{ .pat = ">=", .op = .ge },
+        .{ .pat = "<=", .op = .le },
+        .{ .pat = "!=", .op = .ne },
+    };
     var i: usize = 0;
     var depth: usize = 0;
-    while (i < s.len) {
+    scan: while (i < s.len) {
         if (s[i] == '\'') {
             i += 1;
             while (i < s.len and s[i] != '\'') : (i += 1) {}
@@ -1040,14 +1071,26 @@ fn findTopLevelSubstr(s: []const u8, needle: []const u8) ?usize {
             i += 1;
             continue;
         }
-        if (depth == 0 and i + needle.len <= s.len and
-            std.ascii.eqlIgnoreCase(s[i .. i + needle.len], needle))
-        {
-            return i;
+        if (depth == 0) {
+            for (candidates) |c| {
+                if (i + c.pat.len <= s.len and std.ascii.eqlIgnoreCase(s[i .. i + c.pat.len], c.pat)) {
+                    if (c.op == .not_in or c.op == .in_kw) {
+                        const col_candidate = std.mem.trim(u8, s[0..i], &std.ascii.whitespace);
+                        if (std.mem.indexOfAny(u8, col_candidate, "=<>!'\"(") != null) {
+                            i += 1;
+                            continue :scan; // guard failed — keep scanning past this position
+                        }
+                    }
+                    return .{ .op = c.op, .idx = i };
+                }
+            }
+            if (s[i] == '=') return .{ .op = .eq, .idx = i };
+            if (s[i] == '>') return .{ .op = .gt, .idx = i };
+            if (s[i] == '<') return .{ .op = .lt, .idx = i };
         }
         i += 1;
     }
-    return null;
+    return .{ .op = .none, .idx = 0 };
 }
 
 /// Scan `s` for " KEYWORD " (case-insensitive, with a space on each side) while
@@ -1180,94 +1223,48 @@ pub fn parseExpression(allocator: Allocator, input: []const u8) !Expression {
         return parseBetween(allocator, trimmed, idx);
     }
 
-    // IS NULL / IS NOT NULL — only reached once no top-level AND/OR/BETWEEN
-    // remains, so `trimmed` here is always a single leaf predicate and this
-    // substring scan can't accidentally swallow a sibling predicate.
-    if (findTopLevelSubstr(trimmed, " IS NOT NULL")) |idx| {
-        const col_part = std.mem.trim(u8, trimmed[0..idx], &std.ascii.whitespace);
-        const col_lower = try allocator.alloc(u8, col_part.len);
-        _ = std.ascii.lowerString(col_lower, col_part);
-        return Expression{ .comparison = Comparison{
-            .column = col_lower,
-            .operator = .is_not_null,
-            .value = try allocator.dupe(u8, ""),
-            .numeric_value = null,
-        } };
-    }
-    if (findTopLevelSubstr(trimmed, " IS NULL")) |idx| {
-        const col_part = std.mem.trim(u8, trimmed[0..idx], &std.ascii.whitespace);
-        const col_lower = try allocator.alloc(u8, col_part.len);
-        _ = std.ascii.lowerString(col_lower, col_part);
-        return Expression{ .comparison = Comparison{
-            .column = col_lower,
-            .operator = .is_null,
-            .value = try allocator.dupe(u8, ""),
-            .numeric_value = null,
-        } };
+    // Everything below here is a single leaf predicate (no top-level
+    // AND/OR/BETWEEN remains) — classified in one pass instead of the old
+    // cascade of independent scans. See scanLeafOperator.
+    const leaf = scanLeafOperator(trimmed);
+    switch (leaf.op) {
+        .is_not_null, .is_null => {
+            const col_part = std.mem.trim(u8, trimmed[0..leaf.idx], &std.ascii.whitespace);
+            const col_lower = try allocator.alloc(u8, col_part.len);
+            _ = std.ascii.lowerString(col_lower, col_part);
+            return Expression{ .comparison = Comparison{
+                .column = col_lower,
+                .operator = if (leaf.op == .is_not_null) .is_not_null else .is_null,
+                .value = try allocator.dupe(u8, ""),
+                .numeric_value = null,
+            } };
+        },
+        .ilike => return parseILikeComparison(allocator, trimmed, leaf.idx),
+        .like => return parseLikeComparison(allocator, trimmed, leaf.idx),
+        .not_in, .in_kw => return parseInComparison(allocator, trimmed, leaf.idx, leaf.op == .not_in),
+        else => {},
     }
 
-    // Check for ILIKE before LIKE (both before symbol operators since patterns may contain = > <)
-    if (findTopLevelSubstr(trimmed, " ILIKE ")) |idx| {
-        return parseILikeComparison(allocator, trimmed, idx);
-    }
-    if (findTopLevelSubstr(trimmed, " LIKE ")) |idx| {
-        return parseLikeComparison(allocator, trimmed, idx);
-    }
-
-    // Check for NOT IN (...) before IN (...) — "col NOT IN (" contains " IN ("
-    // as a substring starting after "NOT", so NOT IN must be checked first or
-    // it gets misparsed as a plain IN with "col NOT" as the column name (#115).
-    if (findTopLevelSubstr(trimmed, " NOT IN (")) |idx| {
-        const col_candidate = std.mem.trim(u8, trimmed[0..idx], &std.ascii.whitespace);
-        if (std.mem.indexOfAny(u8, col_candidate, "=<>!'\"(") == null) {
-            // idx (before " NOT IN (") is correct for both ends: column_part
-            // uses input[0..idx] (just the column), and the paren search in
-            // input[idx..] finds '(' regardless of the "NOT IN" text before it.
-            return parseInComparison(allocator, trimmed, idx, true);
-        }
-    }
-
-    // Check for IN (...) operator before = (so "col IN (...)" doesn't match the = path)
-    if (findTopLevelSubstr(trimmed, " IN (")) |idx| {
-        const col_candidate = std.mem.trim(u8, trimmed[0..idx], &std.ascii.whitespace);
-        // Only treat as IN if the left-hand side looks like a plain identifier (no operators/quotes)
-        if (std.mem.indexOfAny(u8, col_candidate, "=<>!'\"(") == null) {
-            return parseInComparison(allocator, trimmed, idx, false);
-        }
-    }
-
-    // Check for scalar function as LHS: DATEDIFF(...) op rhs, DATEADD(...) op rhs,
-    // EXTRACT(... FROM ...) op rhs.  Must come before the bare-operator checks below
-    // so that e.g. DATEDIFF(...) > 5 is not parsed as a plain `>` comparison.
+    // Scalar function as LHS: DATEDIFF(...) op rhs, DATEADD(...) op rhs,
+    // EXTRACT(... FROM ...) op rhs. Every remaining leaf.op case above ends
+    // in a bare comparison operator (or nothing, for a bare function call),
+    // never IS NULL/LIKE/IN — so this can't misfire against those.
     if (try parseScalarWhereComparison(allocator, trimmed)) |expr| return expr;
 
-    // "col % divisor op value" (#119) — must come before the bare-operator
-    // checks below so "id % 2 = 0" isn't parsed as column "id % 2".
-    if (std.mem.indexOf(u8, trimmed, " % ")) |mod_idx| {
-        if (try parseModComparison(allocator, trimmed, mod_idx)) |expr| return expr;
+    // "col % divisor op value" (#119).
+    if (leaf.op == .percent) {
+        if (try parseModComparison(allocator, trimmed, leaf.idx)) |expr| return expr;
     }
 
-    // Check for operators (simple case - no parentheses)
-    if (std.mem.indexOf(u8, trimmed, ">=")) |idx| {
-        return parseComparison(allocator, trimmed, ">=", idx);
-    }
-    if (std.mem.indexOf(u8, trimmed, "<=")) |idx| {
-        return parseComparison(allocator, trimmed, "<=", idx);
-    }
-    if (std.mem.indexOf(u8, trimmed, "!=")) |idx| {
-        return parseComparison(allocator, trimmed, "!=", idx);
-    }
-    if (std.mem.indexOf(u8, trimmed, "=")) |idx| {
-        return parseComparison(allocator, trimmed, "=", idx);
-    }
-    if (std.mem.indexOf(u8, trimmed, ">")) |idx| {
-        return parseComparison(allocator, trimmed, ">", idx);
-    }
-    if (std.mem.indexOf(u8, trimmed, "<")) |idx| {
-        return parseComparison(allocator, trimmed, "<", idx);
-    }
-
-    return error.InvalidExpression;
+    return switch (leaf.op) {
+        .ge => parseComparison(allocator, trimmed, ">=", leaf.idx),
+        .le => parseComparison(allocator, trimmed, "<=", leaf.idx),
+        .ne => parseComparison(allocator, trimmed, "!=", leaf.idx),
+        .eq => parseComparison(allocator, trimmed, "=", leaf.idx),
+        .gt => parseComparison(allocator, trimmed, ">", leaf.idx),
+        .lt => parseComparison(allocator, trimmed, "<", leaf.idx),
+        else => error.InvalidExpression,
+    };
 }
 
 fn parseBetween(allocator: Allocator, input: []const u8, between_idx: usize) !Expression {

--- a/tests/where_expr_precedence_test.zig
+++ b/tests/where_expr_precedence_test.zig
@@ -1,0 +1,236 @@
+// WHERE-expression grammar tests: written before the tokenizer/recursive-
+// descent rewrite of parser.zig's expression parsing (parseExpression and
+// friends). These are the acceptance criteria for that rewrite and the
+// permanent regression tests for #154 (BETWEEN...AND swallowing a
+// trailing OR) and #155 (a subquery's own LIKE/ILIKE/IS NULL/IN mistaken
+// for the outer predicate's operator), both found by bench/query_fuzz.sh.
+//
+// Structural assertions walk the parsed Expression tree directly rather
+// than evaluating rows — the bug class here is entirely about which node
+// the parser builds, not about evaluation logic (already covered
+// elsewhere).
+const std = @import("std");
+const parser = @import("parser");
+
+fn expectComparisonColumn(expr: parser.Expression, expected_col: []const u8) !void {
+    switch (expr) {
+        .comparison => |c| try std.testing.expectEqualStrings(expected_col, c.column),
+        else => return error.NotAComparison,
+    }
+}
+
+// ── #154: BETWEEN...AND combined with a trailing OR/AND ────────────────
+
+test "BETWEEN followed by OR splits at top level, not inside BETWEEN's own AND" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id BETWEEN 10 AND 20 OR city = 'Austin'");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"or", expr.binary.op);
+    try std.testing.expect(expr.binary.left == .comparison);
+    try std.testing.expectEqual(.between, expr.binary.left.comparison.operator);
+    try std.testing.expectEqualStrings("10", expr.binary.left.comparison.value);
+    try std.testing.expectEqualStrings("20", expr.binary.left.comparison.between_high.?);
+    try expectComparisonColumn(expr.binary.right, "city");
+}
+
+test "BETWEEN followed by AND then another predicate splits at the second AND" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id BETWEEN 10 AND 20 AND city = 'Austin'");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"and", expr.binary.op);
+    try std.testing.expectEqual(.between, expr.binary.left.comparison.operator);
+    try expectComparisonColumn(expr.binary.right, "city");
+}
+
+test "two BETWEEN clauses joined by AND both parse correctly" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id BETWEEN 1 AND 5 AND age BETWEEN 20 AND 30");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"and", expr.binary.op);
+    try std.testing.expectEqual(.between, expr.binary.left.comparison.operator);
+    try std.testing.expectEqualStrings("id", expr.binary.left.comparison.column);
+    try std.testing.expectEqual(.between, expr.binary.right.comparison.operator);
+    try std.testing.expectEqualStrings("age", expr.binary.right.comparison.column);
+}
+
+test "BETWEEN wrapped in NOT still parses its own AND correctly" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE NOT (id BETWEEN 10 AND 20)");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .unary);
+    try std.testing.expectEqual(.between, expr.unary.expr.comparison.operator);
+}
+
+// ── #155: a subquery's own predicate keywords must not leak to the outer
+//    IN/NOT IN detection ─────────────────────────────────────────────────
+
+test "IN subquery whose WHERE uses LIKE parses the outer clause as IN, not LIKE" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id IN (SELECT id FROM 'g.csv' WHERE department LIKE 'Op%')");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .comparison);
+    try std.testing.expectEqualStrings("id", expr.comparison.column);
+    try std.testing.expect(expr.comparison.in_subquery_sql != null);
+    try std.testing.expect(std.mem.indexOf(u8, expr.comparison.in_subquery_sql.?, "LIKE") != null);
+}
+
+test "IN subquery whose WHERE uses ILIKE parses the outer clause as IN" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id IN (SELECT id FROM 'g.csv' WHERE department ILIKE 'op%')");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .comparison);
+    try std.testing.expect(expr.comparison.in_subquery_sql != null);
+}
+
+test "NOT IN subquery whose WHERE uses IS NOT NULL parses the outer clause as NOT IN" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id NOT IN (SELECT id FROM 'g.csv' WHERE department IS NOT NULL)");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .comparison);
+    try std.testing.expect(expr.comparison.in_negate);
+    try std.testing.expect(expr.comparison.in_subquery_sql != null);
+}
+
+test "IN subquery whose WHERE itself contains a literal IN list" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id IN (SELECT id FROM 'g.csv' WHERE city IN ('Austin', 'Denver'))");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .comparison);
+    try std.testing.expect(expr.comparison.in_subquery_sql != null);
+    try std.testing.expect(std.mem.indexOf(u8, expr.comparison.in_subquery_sql.?, "IN (") != null);
+}
+
+test "IN subquery combined with an outer AND still splits at the outer AND" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id IN (SELECT id FROM 'g.csv' WHERE department LIKE 'Op%') AND age > 30");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"and", expr.binary.op);
+    try std.testing.expect(expr.binary.left.comparison.in_subquery_sql != null);
+    try expectComparisonColumn(expr.binary.right, "age");
+}
+
+// ── General precedence / structure sanity ───────────────────────────────
+
+test "OR has lower precedence than AND" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE a = 1 AND b = 2 OR c = 3");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"or", expr.binary.op);
+    try std.testing.expect(expr.binary.left == .binary);
+    try std.testing.expectEqual(.@"and", expr.binary.left.binary.op);
+    try expectComparisonColumn(expr.binary.right, "c");
+}
+
+test "explicit parens override default precedence" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE (a = 1 OR b = 2) AND c = 3");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"and", expr.binary.op);
+    try std.testing.expect(expr.binary.left == .binary);
+    try std.testing.expectEqual(.@"or", expr.binary.left.binary.op);
+}
+
+test "three-way AND chain parses all three predicates" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE a = 1 AND b = 2 AND c = 3");
+    defer query.deinit();
+
+    // AND is associative, so either grouping is a valid parse; this pins
+    // down the first-split-point shape the current recursive descent
+    // produces (left = first predicate, right = the rest, itself an AND).
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"and", expr.binary.op);
+    try expectComparisonColumn(expr.binary.left, "a");
+    try std.testing.expect(expr.binary.right == .binary);
+    try expectComparisonColumn(expr.binary.right.binary.left, "b");
+    try expectComparisonColumn(expr.binary.right.binary.right, "c");
+}
+
+test "modulo comparison combined with AND still splits at the AND" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE id % 2 = 0 AND city = 'Austin'");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"and", expr.binary.op);
+    try std.testing.expect(expr.binary.left.comparison.mod_divisor != null);
+    try expectComparisonColumn(expr.binary.right, "city");
+}
+
+test "scalar function comparison combined with OR still splits at the OR" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE DATEDIFF('day', start_col, end_col) > 5 OR city = 'Austin'");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"or", expr.binary.op);
+    try std.testing.expect(expr.binary.left == .scalar_comparison);
+    try expectComparisonColumn(expr.binary.right, "city");
+}
+
+test "IS NULL and IS NOT NULL combined with AND/OR" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE age IS NULL OR city IS NOT NULL");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"or", expr.binary.op);
+    try std.testing.expectEqual(.is_null, expr.binary.left.comparison.operator);
+    try std.testing.expectEqual(.is_not_null, expr.binary.right.comparison.operator);
+}
+
+test "NOT IN literal list does not get misparsed as IN with NOT in the column name" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE department NOT IN ('Sales', 'HR')");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .comparison);
+    try std.testing.expectEqualStrings("department", expr.comparison.column);
+    try std.testing.expect(expr.comparison.in_negate);
+    try std.testing.expectEqual(@as(usize, 2), expr.comparison.in_values.?.len);
+}
+
+test "ILIKE combined with AND still splits at the AND" {
+    const allocator = std.testing.allocator;
+    var query = try parser.parse(allocator, "SELECT id FROM 'f.csv' WHERE name ILIKE '%smith%' AND age > 30");
+    defer query.deinit();
+
+    const expr = query.where_expr.?;
+    try std.testing.expect(expr == .binary);
+    try std.testing.expectEqual(.@"and", expr.binary.op);
+    try std.testing.expectEqual(.ilike, expr.binary.left.comparison.operator);
+    try expectComparisonColumn(expr.binary.right, "age");
+}


### PR DESCRIPTION
Follow-up to #156 (already merged) on the same branch.

- src/memfile.zig: memfd_create()-backed scratch files on Linux for the four internal operations that previously wrote a real temp file (IN-subquery resolution, join+aggregate staging, parallel-JOIN worker staging, --table rendering). macOS/Windows keep the existing real-temp-file behavior for now — documented, tracked in #164, not silently left as-is.
- SECURITY.md: documents the zero-network and zero-disk-write guarantees accurately, including the macOS/Windows exception.

Verified: full unit suite, 103-check DuckDB correctness suite, fuzzer (multiple seeds, thousands of queries, zero mismatches), plus a manual >8MB two-table JOIN+GROUP BY forcing the parallel-JOIN code path (the highest-risk change here) against DuckDB directly.