### PR TITLE
feat: add SIGN scalar function

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The query cost is **flat** — it's the SQL plus a few result rows, independent 
 
 **Full WHERE clause support:** `=`, `!=`, `>`, `>=`, `<`, `<=`, `LIKE`, `BETWEEN`, `IN`, `IS NULL`, `IS NOT NULL`, `NOT`, `AND`, `OR`
 
-**Full SELECT support:** column projections, `AS` aliases, `DISTINCT`, `COUNT`/`SUM`/`AVG`/`MIN`/`MAX`/`VARIANCE`/`STDDEV`/`MEDIAN`/`GROUP_CONCAT`, `GROUP BY`, `HAVING`, `ORDER BY` (by name, alias, or position), `LIMIT`, `STRFTIME()`, `DATE_PART()`, `JOIN`, `UPPER`/`LOWER`/`TRIM`/`LENGTH`/`SUBSTR`/`REPLACE`/`SPLIT_PART`/`GREATEST`/`LEAST`, `ABS`/`CEIL`/`FLOOR`/`MOD`/`ROUND`, `COALESCE`, `CAST`, `DATEDIFF`, `DATEADD`, `EXTRACT`
+**Full SELECT support:** column projections, `AS` aliases, `DISTINCT`, `COUNT`/`SUM`/`AVG`/`MIN`/`MAX`/`VARIANCE`/`STDDEV`/`MEDIAN`/`GROUP_CONCAT`, `GROUP BY`, `HAVING`, `ORDER BY` (by name, alias, or position), `LIMIT`, `STRFTIME()`, `DATE_PART()`, `JOIN`, `UPPER`/`LOWER`/`TRIM`/`LENGTH`/`SUBSTR`/`REPLACE`/`SPLIT_PART`/`GREATEST`/`LEAST`, `ABS`/`SIGN`/`CEIL`/`FLOOR`/`MOD`/`ROUND`, `COALESCE`, `CAST`, `DATEDIFF`, `DATEADD`, `EXTRACT`
 
 ### Setup
 
@@ -320,7 +320,7 @@ Full API, options (delimiter/comment/skip-empty-lines), memory comparisons again
 | `CASE WHEN` inside aggregates       |                                                      | ✅ shipped          |
 | `ILIKE` in WHERE                    |                                                      | ✅ shipped          |
 | `UPPER`, `LOWER`, `TRIM`, `LENGTH`, `SUBSTR` in SELECT |                             | ✅ shipped          |
-| `ABS`, `CEIL`, `FLOOR`, `MOD` in SELECT |                                                 | ✅ shipped          |
+| `ABS`, `SIGN`, `CEIL`, `FLOOR`, `MOD` in SELECT |                                         | ✅ shipped          |
 | `ROUND(col)` / `ROUND(col, n)` in SELECT |                                               | ✅ shipped          |
 | `COALESCE` in SELECT                |                                                      | ✅ shipped          |
 | `CAST` in SELECT                    |                                                      | ✅ shipped          |

--- a/SQL_REFERENCE.md
+++ b/SQL_REFERENCE.md
@@ -41,7 +41,7 @@ Full syntax reference and runnable examples for every SQL feature csvql supports
 | **REPLACE**   | `SELECT REPLACE(col, 'from', 'to')` — replace all occurrences of a substring |
 | **SPLIT_PART**| `SELECT SPLIT_PART(col, 'delim', n)` — n-th field (1-based) after splitting on delim |
 | **GREATEST / LEAST** | `SELECT GREATEST(a, b, ...)`, `LEAST(a, b, ...)` — row-wise max/min (numeric or lexicographic) |
-| **ABS / CEIL / FLOOR** | `SELECT ABS(col), CEIL(col), FLOOR(col)` — numeric functions  |
+| **ABS / SIGN / CEIL / FLOOR** | `SELECT ABS(col), SIGN(col), CEIL(col), FLOOR(col)` — numeric functions; `SIGN` returns `-1`, `0`, or `1` |
 | **MOD**       | `SELECT MOD(col, n)` — modulo by a numeric literal                      |
 | **ROUND**     | `SELECT ROUND(col)` — round to integer; `ROUND(col, n)` — round to `n` decimal places |
 | **COALESCE**  | `SELECT COALESCE(col, 'default')` — replace empty/null with fallback    |
@@ -109,7 +109,7 @@ csvql "SELECT UPPER(name), LOWER(city), TRIM(notes) FROM 'data.csv'"
 csvql "SELECT name, LENGTH(name), SUBSTR(name, 1, 3) FROM 'data.csv'"
 
 # Numeric functions
-csvql "SELECT name, ABS(balance), CEIL(score), FLOOR(score) FROM 'data.csv'"
+csvql "SELECT name, ABS(balance), SIGN(balance), CEIL(score), FLOOR(score) FROM 'data.csv'"
 csvql "SELECT name, MOD(age, 10) AS age_decade FROM 'data.csv'"
 csvql "SELECT name, ROUND(price) AS rounded, ROUND(price, 2) AS price_2dp FROM 'data.csv'"
 

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -292,7 +292,7 @@ pub const parseQuery = parser.parse;
 pub const Query = parser.Query;
 
 /// Return true when any SELECT column is a scalar function that needs per-row
-/// evaluation (UPPER, LOWER, TRIM, LENGTH, SUBSTR, ABS, CEIL, FLOOR, MOD,
+/// evaluation (UPPER, LOWER, TRIM, LENGTH, SUBSTR, ABS, SIGN, CEIL, FLOOR, MOD,
 /// COALESCE, CAST, STRFTIME).  Aggregate functions, SUBSTR-as-GROUP-BY-key,
 /// and CASE WHEN are handled by their own dedicated paths and are excluded.
 fn hasScalarSelectFunctions(query: parser.Query) bool {
@@ -2773,6 +2773,7 @@ fn evalScalarOnSingleValue(spec: scalar.ScalarSpec, value: []const u8, arena: Al
         .trim => |*ci| ci.* = 0,
         .length => |*ci| ci.* = 0,
         .abs => |*ci| ci.* = 0,
+        .sign => |*ci| ci.* = 0,
         .ceil => |*ci| ci.* = 0,
         .floor => |*ci| ci.* = 0,
         .cast_int => |*ci| ci.* = 0,
@@ -7561,7 +7562,7 @@ test "LENGTH: returns string length as integer" {
 // #147 — LENGTH was the one scalar function that did not propagate NULL.
 // An empty CSV field is csvql's NULL (that is what IS NULL, COUNT(col) and
 // COALESCE all agree on), and every other scalar function already returns
-// empty for it — UPPER, LOWER, TRIM, SUBSTR, REPLACE, ABS, CEIL, FLOOR,
+// empty for it — UPPER, LOWER, TRIM, SUBSTR, REPLACE, ABS, SIGN, CEIL, FLOOR,
 // ROUND, CAST. LENGTH alone measured the empty string and returned "0",
 // turning a missing value into a real one.
 test "LENGTH: empty field propagates NULL (empty), not 0 (#147)" {
@@ -7657,6 +7658,35 @@ test "ABS: returns absolute value of negative numbers" {
     try std.testing.expect(std.mem.containsAtLeast(u8, data, 1, "5"));
     // negative sign must be gone
     try std.testing.expect(!std.mem.containsAtLeast(u8, data, 1, "-42"));
+}
+
+test "SIGN: returns -1, 0, or 1" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        const f = try tmp.dir.createFile("sc.csv", .{});
+        defer f.close();
+        try f.writeAll("n\n-42.5\n0\n7.25\n");
+    }
+    var pb: [std.fs.max_path_bytes]u8 = undefined;
+    const p = try tmp.dir.realpath("sc.csv", &pb);
+
+    const sql = try std.fmt.allocPrint(allocator, "SELECT SIGN(n) FROM '{s}'", .{p});
+    defer allocator.free(sql);
+    var q = try parser.parse(allocator, sql);
+    defer q.deinit();
+
+    const out = try tmp.dir.createFile("out.csv", .{ .read = true });
+    defer out.close();
+    try execute(allocator, q, out, .{});
+
+    try out.seekTo(0);
+    const data = try out.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(data);
+
+    try std.testing.expectEqualStrings("SIGN(n)\n-1\n0\n1\n", data);
 }
 
 test "CEIL: rounds up and emits .0 suffix" {

--- a/src/scalar.zig
+++ b/src/scalar.zig
@@ -1,7 +1,7 @@
 /// scalar.zig — Scalar function evaluation for SELECT columns.
 ///
 /// Supports: UPPER, LOWER, TRIM, LENGTH, SUBSTR/SUBSTRING,
-///           ABS, CEIL, FLOOR, MOD, COALESCE, CAST(col AS type), REPLACE,
+///           ABS, SIGN, CEIL, FLOOR, MOD, COALESCE, CAST(col AS type), REPLACE,
 ///           SPLIT_PART, GREATEST, LEAST
 ///
 /// Usage:
@@ -26,6 +26,7 @@ pub const ScalarSpec = union(enum) {
     length: usize, // LENGTH(col) — returns character count as string
     substr: SubstrArgs, // SUBSTR(col, start[, len]) — 1-based SQL semantics
     abs: usize, // ABS(col)
+    sign: usize, // SIGN(col)
     ceil: usize, // CEIL(col)
     floor: usize, // FLOOR(col)
     mod_op: ModArgs, // MOD(col, divisor)
@@ -169,7 +170,7 @@ pub const ScalarSpec = union(enum) {
     /// Return the primary column index this spec operates on.
     pub fn colIdx(self: ScalarSpec) usize {
         return switch (self) {
-            .upper, .lower, .trim, .length, .abs, .ceil, .floor, .cast_int, .cast_float, .cast_text => |i| i,
+            .upper, .lower, .trim, .length, .abs, .sign, .ceil, .floor, .cast_int, .cast_float, .cast_text => |i| i,
             .substr => |a| a.col_idx,
             .mod_op => |a| a.col_idx,
             .coalesce => |a| a.cols()[0],
@@ -255,6 +256,7 @@ pub fn tryParseScalar(
         std.mem.eql(u8, fn_lower, "trim") or
         std.mem.eql(u8, fn_lower, "length") or
         std.mem.eql(u8, fn_lower, "abs") or
+        std.mem.eql(u8, fn_lower, "sign") or
         std.mem.eql(u8, fn_lower, "ceil") or
         std.mem.eql(u8, fn_lower, "ceiling") or
         std.mem.eql(u8, fn_lower, "floor");
@@ -289,6 +291,7 @@ pub fn tryParseScalar(
         if (std.mem.eql(u8, fn_lower, "trim")) return .{ .trim = cidx };
         if (std.mem.eql(u8, fn_lower, "length")) return .{ .length = cidx };
         if (std.mem.eql(u8, fn_lower, "abs")) return .{ .abs = cidx };
+        if (std.mem.eql(u8, fn_lower, "sign")) return .{ .sign = cidx };
         if (std.mem.eql(u8, fn_lower, "ceil") or std.mem.eql(u8, fn_lower, "ceiling")) return .{ .ceil = cidx };
         if (std.mem.eql(u8, fn_lower, "floor")) return .{ .floor = cidx };
     }
@@ -822,6 +825,11 @@ pub fn eval(spec: ScalarSpec, record: []const []const u8, arena: Allocator) []co
             const n = std.fmt.parseFloat(f64, v) catch return v;
             const buf = arena.alloc(u8, 32) catch return v;
             return fmtNum(buf, @abs(n));
+        },
+        .sign => |cidx| {
+            const v = field(record, cidx);
+            const n = std.fmt.parseFloat(f64, v) catch return v;
+            return if (n < 0) "-1" else if (n > 0) "1" else "0";
         },
         .ceil => |cidx| {
             const v = field(record, cidx);


### PR DESCRIPTION
Fixes #158.

Adds `SIGN(col)` as an ABS-style scalar function: it parses a single column and returns `-1`, `0`, or `1`. The SQL reference and an end-to-end regression test cover the new function.

Tests:
- `zig build test --summary all` (590/590)
- `zig fmt --check src/ tests/ build.zig`
- `zig build --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`