### PR TITLE
feat: add REVERSE string function

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The query cost is **flat** — it's the SQL plus a few result rows, independent 
 
 **Full WHERE clause support:** `=`, `!=`, `>`, `>=`, `<`, `<=`, `LIKE`, `BETWEEN`, `IN`, `IS NULL`, `IS NOT NULL`, `NOT`, `AND`, `OR`
 
-**Full SELECT support:** column projections, `AS` aliases, `DISTINCT`, `COUNT`/`SUM`/`AVG`/`MIN`/`MAX`/`VARIANCE`/`STDDEV`/`MEDIAN`/`GROUP_CONCAT`, `GROUP BY`, `HAVING`, `ORDER BY` (by name, alias, or position), `LIMIT`, `STRFTIME()`, `DATE_PART()`, `JOIN`, `UPPER`/`LOWER`/`TRIM`/`LENGTH`/`SUBSTR`/`REPLACE`/`SPLIT_PART`/`GREATEST`/`LEAST`, `ABS`/`SIGN`/`CEIL`/`FLOOR`/`MOD`/`ROUND`, `COALESCE`, `CAST`, `DATEDIFF`, `DATEADD`, `EXTRACT`
+**Full SELECT support:** column projections, `AS` aliases, `DISTINCT`, `COUNT`/`SUM`/`AVG`/`MIN`/`MAX`/`VARIANCE`/`STDDEV`/`MEDIAN`/`GROUP_CONCAT`, `GROUP BY`, `HAVING`, `ORDER BY` (by name, alias, or position), `LIMIT`, `STRFTIME()`, `DATE_PART()`, `JOIN`, `UPPER`/`LOWER`/`TRIM`/`REVERSE`/`LENGTH`/`SUBSTR`/`REPLACE`/`SPLIT_PART`/`GREATEST`/`LEAST`, `ABS`/`SIGN`/`CEIL`/`FLOOR`/`MOD`/`ROUND`, `COALESCE`, `CAST`, `DATEDIFF`, `DATEADD`, `EXTRACT`
 
 ### Setup
 
@@ -319,7 +319,7 @@ Full API, options (delimiter/comment/skip-empty-lines), memory comparisons again
 | `GROUP BY` alias (`GROUP BY month`) |                                                      | ✅ shipped          |
 | `CASE WHEN` inside aggregates       |                                                      | ✅ shipped          |
 | `ILIKE` in WHERE                    |                                                      | ✅ shipped          |
-| `UPPER`, `LOWER`, `TRIM`, `LENGTH`, `SUBSTR` in SELECT |                             | ✅ shipped          |
+| `UPPER`, `LOWER`, `TRIM`, `REVERSE`, `LENGTH`, `SUBSTR` in SELECT |                  | ✅ shipped          |
 | `ABS`, `SIGN`, `CEIL`, `FLOOR`, `MOD` in SELECT |                                         | ✅ shipped          |
 | `ROUND(col)` / `ROUND(col, n)` in SELECT |                                               | ✅ shipped          |
 | `COALESCE` in SELECT                |                                                      | ✅ shipped          |

--- a/SQL_REFERENCE.md
+++ b/SQL_REFERENCE.md
@@ -35,6 +35,7 @@ Full syntax reference and runnable examples for every SQL feature csvql supports
 | **DATE_PART** | `DATE_PART('year', col)` — extract `year`/`month`/`day`/`hour`/`minute`/`second`; alias for `STRFTIME` in `SELECT` and `GROUP BY` |
 | **UPPER / LOWER** | `SELECT UPPER(col), LOWER(col)` — case conversion; one level of nesting supported, e.g. `LOWER(TRIM(col))` |
 | **TRIM**      | `SELECT TRIM(col)` — strip leading and trailing whitespace; nestable, e.g. `TRIM(UPPER(col))` |
+| **REVERSE**   | `SELECT REVERSE(col)` — reverse a string by Unicode code point; nestable, e.g. `REVERSE(TRIM(col))` |
 | **LENGTH**    | `SELECT LENGTH(col)` — byte length of the value; nestable, e.g. `LENGTH(TRIM(col))` |
 | **CONCAT**    | `SELECT CONCAT(col1, '-', col2, ...)` — concatenate columns and/or string literals |
 | **SUBSTR**    | `SELECT SUBSTR(col, start, len)` — substring (1-based, `len` optional)  |

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -292,7 +292,7 @@ pub const parseQuery = parser.parse;
 pub const Query = parser.Query;
 
 /// Return true when any SELECT column is a scalar function that needs per-row
-/// evaluation (UPPER, LOWER, TRIM, LENGTH, SUBSTR, ABS, SIGN, CEIL, FLOOR, MOD,
+/// evaluation (UPPER, LOWER, TRIM, REVERSE, LENGTH, SUBSTR, ABS, SIGN, CEIL, FLOOR, MOD,
 /// COALESCE, CAST, STRFTIME).  Aggregate functions, SUBSTR-as-GROUP-BY-key,
 /// and CASE WHEN are handled by their own dedicated paths and are excluded.
 fn hasScalarSelectFunctions(query: parser.Query) bool {
@@ -657,7 +657,10 @@ fn executeSequential(
 
     // Determine output columns
     var output_specs = std.ArrayListUnmanaged(scalar.OutputColSpec){};
-    defer output_specs.deinit(allocator);
+    defer {
+        for (output_specs.items) |*spec| spec.deinit(allocator);
+        output_specs.deinit(allocator);
+    }
 
     var output_header = std.ArrayList([]const u8){};
     defer output_header.deinit(allocator);
@@ -673,9 +676,13 @@ fn executeSequential(
             const expr = sa.expr;
 
             // Try scalar function first (UPPER, LOWER, TRIM, etc.)
-            if (try scalar.tryParseScalar(expr, column_map, allocator)) |sc_spec| {
-                try output_specs.append(allocator, .{ .scalar = sc_spec });
-                try output_header.append(allocator, if (sa.alias) |a| a else expr);
+            if (try scalar.tryParseScalar(expr, column_map, allocator)) |parsed_spec| {
+                var sc_spec = parsed_spec;
+                {
+                    errdefer sc_spec.deinit(allocator);
+                    try output_header.append(allocator, if (sa.alias) |a| a else expr);
+                    try output_specs.append(allocator, .{ .scalar = sc_spec });
+                }
                 continue;
             }
 
@@ -1247,7 +1254,10 @@ fn executeParallelScalar(
 
     // Build output_specs + output header names
     var output_specs_list = std.ArrayListUnmanaged(scalar.OutputColSpec){};
-    defer output_specs_list.deinit(allocator);
+    defer {
+        for (output_specs_list.items) |*spec| spec.deinit(allocator);
+        output_specs_list.deinit(allocator);
+    }
     var output_header = std.ArrayList([]const u8){};
     defer output_header.deinit(allocator);
 
@@ -1260,9 +1270,13 @@ fn executeParallelScalar(
         for (query.columns) |col| {
             const sa = splitAlias(col);
             const expr = sa.expr;
-            if (try scalar.tryParseScalar(expr, column_map, allocator)) |sc_spec| {
-                try output_specs_list.append(allocator, .{ .scalar = sc_spec });
-                try output_header.append(allocator, if (sa.alias) |a| a else expr);
+            if (try scalar.tryParseScalar(expr, column_map, allocator)) |parsed_spec| {
+                var sc_spec = parsed_spec;
+                {
+                    errdefer sc_spec.deinit(allocator);
+                    try output_header.append(allocator, if (sa.alias) |a| a else expr);
+                    try output_specs_list.append(allocator, .{ .scalar = sc_spec });
+                }
                 continue;
             }
             const lower_col = try allocator.alloc(u8, expr.len);
@@ -2215,7 +2229,10 @@ fn executeFromStdin(
 
     // Determine output columns
     var output_specs = std.ArrayListUnmanaged(scalar.OutputColSpec){};
-    defer output_specs.deinit(allocator);
+    defer {
+        for (output_specs.items) |*spec| spec.deinit(allocator);
+        output_specs.deinit(allocator);
+    }
 
     var output_header = std.ArrayList([]const u8){};
     defer output_header.deinit(allocator);
@@ -2231,9 +2248,13 @@ fn executeFromStdin(
             const expr = sa.expr;
 
             // Try scalar function first (UPPER, LOWER, TRIM, etc.)
-            if (try scalar.tryParseScalar(expr, column_map, allocator)) |sc_spec| {
-                try output_specs.append(allocator, .{ .scalar = sc_spec });
-                try output_header.append(allocator, if (sa.alias) |a| a else expr);
+            if (try scalar.tryParseScalar(expr, column_map, allocator)) |parsed_spec| {
+                var sc_spec = parsed_spec;
+                {
+                    errdefer sc_spec.deinit(allocator);
+                    try output_header.append(allocator, if (sa.alias) |a| a else expr);
+                    try output_specs.append(allocator, .{ .scalar = sc_spec });
+                }
                 continue;
             }
 
@@ -2411,6 +2432,14 @@ const ColKind = union(enum) {
     /// group at output time against agg_results[agg_idx] (#113), e.g.
     /// SELECT dept, CASE WHEN AVG(salary) > 80000 THEN 'high' ELSE 'low' END.
     agg_case: struct { agg_idx: usize, spec: scalar.ScalarSpec },
+
+    fn deinit(self: *ColKind, allocator: Allocator) void {
+        switch (self.*) {
+            .group_key_scalar => |*value| value.spec.deinit(allocator),
+            .agg_case => |*value| value.spec.deinit(allocator),
+            else => {},
+        }
+    }
 };
 
 /// Describes a STRFTIME('%Y-%m', col) GROUP BY / SELECT expression.
@@ -2761,6 +2790,7 @@ fn evalScalarOnSingleValue(spec: scalar.ScalarSpec, value: []const u8, arena: Al
             .upper => scalar.eval(.{ .upper = 0 }, &inner_rec, arena),
             .lower => scalar.eval(.{ .lower = 0 }, &inner_rec, arena),
             .trim => scalar.eval(.{ .trim = 0 }, &inner_rec, arena),
+            .reverse => scalar.eval(.{ .reverse = 0 }, &inner_rec, arena),
             .length => scalar.eval(.{ .length = 0 }, &inner_rec, arena),
         };
     }
@@ -2771,6 +2801,7 @@ fn evalScalarOnSingleValue(spec: scalar.ScalarSpec, value: []const u8, arena: Al
         .upper => |*ci| ci.* = 0,
         .lower => |*ci| ci.* = 0,
         .trim => |*ci| ci.* = 0,
+        .reverse => |*ci| ci.* = 0,
         .length => |*ci| ci.* = 0,
         .abs => |*ci| ci.* = 0,
         .sign => |*ci| ci.* = 0,
@@ -3648,7 +3679,10 @@ fn executeScalarAgg(
 
     // -- Resolve SELECT into ColKind + AggSpec lists --
     var col_kinds = std.ArrayListUnmanaged(ColKind){};
-    defer col_kinds.deinit(allocator);
+    defer {
+        for (col_kinds.items) |*kind| kind.deinit(allocator);
+        col_kinds.deinit(allocator);
+    }
     var agg_specs = std.ArrayListUnmanaged(AggSpec){};
     defer {
         for (agg_specs.items) |spec| {
@@ -4966,7 +5000,10 @@ fn executeGroupBy(
 
     // -- Resolve SELECT columns into ColKind + AggSpec lists ---------------
     var col_kinds = std.ArrayListUnmanaged(ColKind){};
-    defer col_kinds.deinit(allocator);
+    defer {
+        for (col_kinds.items) |*kind| kind.deinit(allocator);
+        col_kinds.deinit(allocator);
+    }
 
     var agg_specs = std.ArrayListUnmanaged(AggSpec){};
     defer {
@@ -5138,21 +5175,25 @@ fn executeGroupBy(
                     } else {
                         // Try scalar function applied to a plain GROUP BY column
                         // e.g. SELECT UPPER(city), COUNT(*) FROM x GROUP BY city
-                        if (try scalar.tryParseScalar(effective_col, column_map, allocator)) |sc_spec| {
-                            // Find which group_spec slot contains this column
-                            const sc_col_idx = sc_spec.colIdx();
-                            var sc_gi: ?usize = null;
-                            for (group_specs, 0..) |spec, gi| {
-                                if (spec == .column and spec.column == sc_col_idx) {
-                                    sc_gi = gi;
-                                    break;
+                        if (try scalar.tryParseScalar(effective_col, column_map, allocator)) |parsed_spec| {
+                            var sc_spec = parsed_spec;
+                            {
+                                errdefer sc_spec.deinit(allocator);
+                                // Find which group_spec slot contains this column
+                                const sc_col_idx = sc_spec.colIdx();
+                                var sc_gi: ?usize = null;
+                                for (group_specs, 0..) |spec, gi| {
+                                    if (spec == .column and spec.column == sc_col_idx) {
+                                        sc_gi = gi;
+                                        break;
+                                    }
                                 }
-                            }
-                            if (sc_gi) |gi| {
-                                try col_kinds.append(allocator, .{ .group_key_scalar = .{ .gi = gi, .spec = sc_spec } });
-                                try out_header_list.append(allocator, if (sa.alias) |a| a else effective_col);
-                            } else {
-                                return columnLookupError(effective_col);
+                                if (sc_gi) |gi| {
+                                    try out_header_list.append(allocator, if (sa.alias) |a| a else effective_col);
+                                    try col_kinds.append(allocator, .{ .group_key_scalar = .{ .gi = gi, .spec = sc_spec } });
+                                } else {
+                                    return columnLookupError(effective_col);
+                                }
                             }
                         } else {
                             return columnLookupError(effective_col);
@@ -7545,6 +7586,47 @@ test "TRIM: strips leading and trailing whitespace" {
     try std.testing.expect(std.mem.containsAtLeast(u8, data, 1, "world"));
     // whitespace must not surround the values in the output
     try std.testing.expect(!std.mem.containsAtLeast(u8, data, 1, "  hello  "));
+}
+
+test "REVERSE: reverses string values" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        const f = try tmp.dir.createFile("sc.csv", .{});
+        defer f.close();
+        try f.writeAll("word\nabc\nstressed\ncafé\n한글\n\" padded \"\n");
+    }
+    var pb: [std.fs.max_path_bytes]u8 = undefined;
+    const p = try tmp.dir.realpath("sc.csv", &pb);
+
+    const sql = try std.fmt.allocPrint(
+        allocator,
+        "SELECT REVERSE(word), REVERSE(UPPER(word)), TRIM(REVERSE(word)) FROM '{s}'",
+        .{p},
+    );
+    defer allocator.free(sql);
+    var q = try parser.parse(allocator, sql);
+    defer q.deinit();
+
+    const out = try tmp.dir.createFile("out.csv", .{ .read = true });
+    defer out.close();
+    try execute(allocator, q, out, .{});
+
+    try out.seekTo(0);
+    const data = try out.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(data);
+
+    try std.testing.expectEqualStrings(
+        "REVERSE(word),REVERSE(UPPER(word)),TRIM(REVERSE(word))\n" ++
+            "cba,CBA,cba\n" ++
+            "desserts,DESSERTS,desserts\n" ++
+            "éfac,éFAC,éfac\n" ++
+            "글한,글한,글한\n" ++
+            " deddap , DEDDAP ,deddap\n",
+        data,
+    );
 }
 
 test "LENGTH: returns string length as integer" {

--- a/src/scalar.zig
+++ b/src/scalar.zig
@@ -1,6 +1,6 @@
 /// scalar.zig — Scalar function evaluation for SELECT columns.
 ///
-/// Supports: UPPER, LOWER, TRIM, LENGTH, SUBSTR/SUBSTRING,
+/// Supports: UPPER, LOWER, TRIM, REVERSE, LENGTH, SUBSTR/SUBSTRING,
 ///           ABS, SIGN, CEIL, FLOOR, MOD, COALESCE, CAST(col AS type), REPLACE,
 ///           SPLIT_PART, GREATEST, LEAST
 ///
@@ -23,6 +23,7 @@ pub const ScalarSpec = union(enum) {
     upper: usize, // UPPER(col)
     lower: usize, // LOWER(col)
     trim: usize, // TRIM(col)
+    reverse: usize, // REVERSE(col)
     length: usize, // LENGTH(col) — returns character count as string
     substr: SubstrArgs, // SUBSTR(col, start[, len]) — 1-based SQL semantics
     abs: usize, // ABS(col)
@@ -144,7 +145,7 @@ pub const ScalarSpec = union(enum) {
     /// same record. Heap-allocated (query-lifetime allocator) since ScalarSpec
     /// can't hold itself by value.
     pub const NestedArgs = struct {
-        pub const OuterFn = enum { upper, lower, trim, length };
+        pub const OuterFn = enum { upper, lower, trim, reverse, length };
         outer_fn: OuterFn,
         inner: *const ScalarSpec,
     };
@@ -170,7 +171,7 @@ pub const ScalarSpec = union(enum) {
     /// Return the primary column index this spec operates on.
     pub fn colIdx(self: ScalarSpec) usize {
         return switch (self) {
-            .upper, .lower, .trim, .length, .abs, .sign, .ceil, .floor, .cast_int, .cast_float, .cast_text => |i| i,
+            .upper, .lower, .trim, .reverse, .length, .abs, .sign, .ceil, .floor, .cast_int, .cast_float, .cast_text => |i| i,
             .substr => |a| a.col_idx,
             .mod_op => |a| a.col_idx,
             .coalesce => |a| a.cols()[0],
@@ -192,12 +193,31 @@ pub const ScalarSpec = union(enum) {
             .nested => |a| a.inner.colIdx(),
         };
     }
+
+    /// Release query-lifetime allocations owned by this spec.
+    pub fn deinit(self: *ScalarSpec, allocator: Allocator) void {
+        switch (self.*) {
+            .nested => |args| {
+                const inner = @constCast(args.inner);
+                inner.deinit(allocator);
+                allocator.destroy(inner);
+            },
+            else => {},
+        }
+    }
 };
 
 /// A SELECT output column: either a direct field pass-through or a scalar transform.
 pub const OutputColSpec = union(enum) {
     column: usize,
     scalar: ScalarSpec,
+
+    pub fn deinit(self: *OutputColSpec, allocator: Allocator) void {
+        switch (self.*) {
+            .scalar => |*spec| spec.deinit(allocator),
+            .column => {},
+        }
+    }
 };
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -254,6 +274,7 @@ pub fn tryParseScalar(
     const single_arg_fn = std.mem.eql(u8, fn_lower, "upper") or
         std.mem.eql(u8, fn_lower, "lower") or
         std.mem.eql(u8, fn_lower, "trim") or
+        std.mem.eql(u8, fn_lower, "reverse") or
         std.mem.eql(u8, fn_lower, "length") or
         std.mem.eql(u8, fn_lower, "abs") or
         std.mem.eql(u8, fn_lower, "sign") or
@@ -274,12 +295,15 @@ pub fn tryParseScalar(
                 .lower
             else if (std.mem.eql(u8, fn_lower, "trim"))
                 .trim
+            else if (std.mem.eql(u8, fn_lower, "reverse"))
+                .reverse
             else if (std.mem.eql(u8, fn_lower, "length"))
                 .length
             else
                 return error.NestedFunctionNotSupported;
-            const inner_spec = try tryParseScalar(args_str, column_map, allocator) orelse
+            var inner_spec = try tryParseScalar(args_str, column_map, allocator) orelse
                 return error.ColumnNotFound;
+            errdefer inner_spec.deinit(allocator);
             const inner_ptr = try allocator.create(ScalarSpec);
             inner_ptr.* = inner_spec;
             return .{ .nested = .{ .outer_fn = outer_fn, .inner = inner_ptr } };
@@ -289,6 +313,7 @@ pub fn tryParseScalar(
         if (std.mem.eql(u8, fn_lower, "upper")) return .{ .upper = cidx };
         if (std.mem.eql(u8, fn_lower, "lower")) return .{ .lower = cidx };
         if (std.mem.eql(u8, fn_lower, "trim")) return .{ .trim = cidx };
+        if (std.mem.eql(u8, fn_lower, "reverse")) return .{ .reverse = cidx };
         if (std.mem.eql(u8, fn_lower, "length")) return .{ .length = cidx };
         if (std.mem.eql(u8, fn_lower, "abs")) return .{ .abs = cidx };
         if (std.mem.eql(u8, fn_lower, "sign")) return .{ .sign = cidx };
@@ -722,6 +747,29 @@ pub fn eval(spec: ScalarSpec, record: []const []const u8, arena: Allocator) []co
         .trim => |cidx| {
             return std.mem.trim(u8, field(record, cidx), &std.ascii.whitespace);
         },
+        .reverse => |cidx| {
+            const v = field(record, cidx);
+            if (v.len == 0) return v;
+            const buf = arena.alloc(u8, v.len) catch return v;
+            if (!std.unicode.utf8ValidateSlice(v)) {
+                @memcpy(buf, v);
+                std.mem.reverse(u8, buf);
+                return buf;
+            }
+            var src_end = v.len;
+            var dst_start: usize = 0;
+            while (src_end > 0) {
+                var src_start = src_end - 1;
+                while (src_start > 0 and v[src_start] & 0xc0 == 0x80) {
+                    src_start -= 1;
+                }
+                const codepoint = v[src_start..src_end];
+                @memcpy(buf[dst_start .. dst_start + codepoint.len], codepoint);
+                dst_start += codepoint.len;
+                src_end = src_start;
+            }
+            return buf;
+        },
         .replace => |args| {
             const v = field(record, args.col_idx);
             if (args.from.len == 0 or std.mem.indexOf(u8, v, args.from) == null) return v;
@@ -746,6 +794,7 @@ pub fn eval(spec: ScalarSpec, record: []const []const u8, arena: Allocator) []co
                 .upper => eval(.{ .upper = 0 }, &inner_rec, arena),
                 .lower => eval(.{ .lower = 0 }, &inner_rec, arena),
                 .trim => eval(.{ .trim = 0 }, &inner_rec, arena),
+                .reverse => eval(.{ .reverse = 0 }, &inner_rec, arena),
                 .length => eval(.{ .length = 0 }, &inner_rec, arena),
             };
         },
@@ -1121,6 +1170,34 @@ test "COALESCE 2-arg backwards compat" {
     try std.testing.expectEqualStrings("unknown", eval(spec, &.{""}, fba.allocator()));
     fba.reset();
     try std.testing.expectEqualStrings("Alice", eval(spec, &.{"Alice"}, fba.allocator()));
+}
+
+test "REVERSE supports direct and nested string transforms" {
+    var parse_arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer parse_arena.deinit();
+    const allocator = parse_arena.allocator();
+
+    var column_map = std.StringHashMap(usize).init(allocator);
+    try column_map.put("word", 0);
+
+    var direct = (try tryParseScalar("REVERSE(word)", column_map, allocator)).?;
+    defer direct.deinit(allocator);
+    var outer = (try tryParseScalar("REVERSE(UPPER(word))", column_map, allocator)).?;
+    defer outer.deinit(allocator);
+    var inner = (try tryParseScalar("TRIM(REVERSE(word))", column_map, allocator)).?;
+    defer inner.deinit(allocator);
+
+    var buf: [128]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&buf);
+    try std.testing.expectEqualStrings("éfac", eval(direct, &.{"café"}, fba.allocator()));
+    fba.reset();
+    try std.testing.expectEqualStrings("éFAC", eval(outer, &.{"café"}, fba.allocator()));
+    fba.reset();
+    try std.testing.expectEqualStrings("cba", eval(inner, &.{" abc "}, fba.allocator()));
+    fba.reset();
+    const invalid = [_]u8{ 0xff, 'a', 0xc0 };
+    const expected_invalid = [_]u8{ 0xc0, 'a', 0xff };
+    try std.testing.expectEqualSlices(u8, expected_invalid[0..], eval(direct, &.{invalid[0..]}, fba.allocator()));
 }
 
 test "COALESCE 3-arg returns first non-empty column" {


### PR DESCRIPTION
Closes #159

## Summary
- add Unicode-safe `REVERSE(col)` evaluation, including nested string functions
- release nested scalar specs after query execution and document the function

## Tests
- `zig build test --summary all` (596/596)
- `zig build --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig fmt --check src/ tests/ build.zig`
